### PR TITLE
Switch files to NIO API

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/Builder.kt
+++ b/src/main/kotlin/org/pkl/lsp/Builder.kt
@@ -15,11 +15,14 @@
  */
 package org.pkl.lsp
 
-import java.io.File
 import java.io.IOException
 import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.isDirectory
+import kotlin.io.path.readText
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.eclipse.lsp4j.PublishDiagnosticsParams
@@ -109,10 +112,10 @@ class Builder(private val server: PklLSPServer, project: Project) : Component(pr
       return null
     }
 
-    fun fileToModule(file: File, virtualFile: VirtualFile): PklModule? {
-      if (!file.exists() || file.isDirectory) return null
-      val change = file.readText()
-      return fileToModule(change, file.normalize().toURI(), virtualFile)
+    fun fileToModule(path: Path, virtualFile: VirtualFile): PklModule? {
+      if (!Files.exists(path) || path.isDirectory()) return null
+      val change = path.readText()
+      return fileToModule(change, path.normalize().toUri(), virtualFile)
     }
 
     fun fileToModule(contents: String, uri: URI, virtualFile: VirtualFile): PklModule? {

--- a/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
@@ -15,9 +15,9 @@
  */
 package org.pkl.lsp
 
-import java.io.File
 import java.io.IOException
 import java.net.URI
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
@@ -59,7 +59,7 @@ class PklTextDocumentService(private val server: PklLSPServer, project: Project)
     }
     try {
       val contents = IoUtils.readString(uri.toURL())
-      server.builder().requestBuild(uri, FsFile(File(uri), project), contents)
+      server.builder().requestBuild(uri, FsFile(Path.of(uri), project), contents)
     } catch (e: IOException) {
       logger.error("Error reading $uri: ${e.message}")
     }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -15,7 +15,7 @@
  */
 package org.pkl.lsp.ast
 
-import java.io.File
+import java.nio.file.Path
 import org.antlr.v4.runtime.tree.ParseTree
 import org.pkl.lsp.*
 import org.pkl.lsp.LSPUtil.firstInstanceOf
@@ -106,8 +106,8 @@ class PklModuleUriImpl(project: Project, override val parent: Node, override val
     }
 
     private fun findByAbsolutePath(sourceFile: VirtualFile, targetPath: String): PklModule? {
-      val file = File(targetPath)
-      return Builder.fileToModule(file, FsFile(file, sourceFile.project))
+      val path = Path.of(targetPath)
+      return Builder.fileToModule(path, FsFile(path, sourceFile.project))
     }
 
     private fun findTripleDotPathOnFileSystem(

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNodeFactory.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNodeFactory.kt
@@ -15,8 +15,8 @@
  */
 package org.pkl.lsp.ast
 
-import java.io.File
 import java.net.URI
+import java.nio.file.Path
 import org.pkl.core.parser.Parser
 import org.pkl.lsp.FsFile
 import org.pkl.lsp.Project
@@ -24,7 +24,11 @@ import org.pkl.lsp.Project
 object PklNodeFactory {
   @Suppress("MemberVisibilityCanBePrivate")
   fun createModule(project: Project, text: String): PklModule {
-    return PklModuleImpl(parser.parseModule(text), URI("fake:module"), FsFile(File("."), project))
+    return PklModuleImpl(
+      parser.parseModule(text),
+      URI("fake:module"),
+      FsFile(Path.of("."), project),
+    )
   }
 
   fun createTypeParameter(project: Project, name: String): PklTypeParameter {

--- a/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
@@ -113,7 +113,7 @@ abstract class LSPTestBase {
 
   private fun parseAndStoreModule(contents: String, path: Path): PklModule {
     val moduleCtx = parser.parseModule(contents)
-    return PklModuleImpl(moduleCtx, path.toUri(), FsFile(path.toFile(), fakeProject)).also {
+    return PklModuleImpl(moduleCtx, path.toUri(), FsFile(path, fakeProject)).also {
       modules[path.toUri()] = it
     }
   }


### PR DESCRIPTION
`java.io.File` is a legacy API; it's better to use `java.nio.file.Path` whenever possible.

This doesn't change `JarFile` because that one isn't used and perhaps should be removed (`Path` can represent files inside a jar).

This is built on top of https://github.com/apple/pkl-lsp/pull/5 and https://github.com/apple/pkl-lsp/pull/6. Only the last commit should be reviewed.