### PR TITLE
rename Node to PklNode

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/Builder.kt
+++ b/src/main/kotlin/org/pkl/lsp/Builder.kt
@@ -30,9 +30,9 @@ import org.pkl.core.parser.LexParseException
 import org.pkl.core.parser.Parser
 import org.pkl.lsp.LSPUtil.toRange
 import org.pkl.lsp.analyzers.*
-import org.pkl.lsp.ast.Node
 import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklModuleImpl
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.Span
 
 class Builder(private val server: PklLSPServer, project: Project) : Component(project) {
@@ -79,7 +79,7 @@ class Builder(private val server: PklLSPServer, project: Project) : Component(pr
     }
   }
 
-  private fun analyze(node: Node): List<Diagnostic> {
+  private fun analyze(node: PklNode): List<Diagnostic> {
     return buildList<PklDiagnostic> {
       for (analyzer in analyzers) {
         analyzer.analyze(node, this)

--- a/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
@@ -79,7 +79,7 @@ open class PklVisitor<R> {
     return visitType(o)
   }
 
-  open fun visitElement(o: Node): R? {
+  open fun visitElement(o: PklNode): R? {
     return null
   }
 

--- a/src/main/kotlin/org/pkl/lsp/analyzers/Analyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/Analyzer.kt
@@ -18,7 +18,7 @@ package org.pkl.lsp.analyzers
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.pkl.lsp.Component
 import org.pkl.lsp.Project
-import org.pkl.lsp.ast.Node
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.isInStdlib
 
 /**
@@ -27,7 +27,7 @@ import org.pkl.lsp.ast.isInStdlib
  * Diagnostics then get reported back to the user.
  */
 abstract class Analyzer(project: Project) : Component(project) {
-  fun analyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>) {
+  fun analyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>) {
     if (node.isInStdlib()) return
     if (!doAnalyze(node, diagnosticsHolder)) {
       return
@@ -42,13 +42,13 @@ abstract class Analyzer(project: Project) : Component(project) {
    * [doAnalyze] on its children.
    */
   protected abstract fun doAnalyze(
-    node: Node,
+    node: PklNode,
     diagnosticsHolder: MutableList<PklDiagnostic>,
   ): Boolean
 
-  protected fun warn(node: Node, message: String): PklDiagnostic =
+  protected fun warn(node: PklNode, message: String): PklDiagnostic =
     PklDiagnostic(node, message, DiagnosticSeverity.Warning)
 
-  protected fun error(node: Node, message: String): PklDiagnostic =
+  protected fun error(node: PklNode, message: String): PklDiagnostic =
     PklDiagnostic(node, message, DiagnosticSeverity.Error)
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
@@ -21,7 +21,7 @@ import org.pkl.lsp.ast.*
 import org.pkl.lsp.type.computeThisType
 
 class AnnotationAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
     if (node !is PklAnnotation) return true
     val type = node.type ?: return true
     if (type !is PklDeclaredType) {

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ImportAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ImportAnalyzer.kt
@@ -17,12 +17,12 @@ package org.pkl.lsp.analyzers
 
 import java.net.URI
 import org.pkl.lsp.*
-import org.pkl.lsp.ast.Node
 import org.pkl.lsp.ast.PklImportBase
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.escapedText
 
 class ImportAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
     if (node !is PklImportBase) {
       return true
     }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
@@ -32,7 +32,7 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
     private val OBJECT_PROPERTY_MODIFIERS = setOf(LOCAL)
   }
 
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
     // removing module and module declaration because this will be checked in PklModuleHeader
     if (
       node !is ModifierListOwner ||
@@ -43,11 +43,11 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
       return true
     }
 
-    var localModifier: Node? = null
-    var abstractModifier: Node? = null
-    var openModifier: Node? = null
-    var hiddenModifier: Node? = null
-    var fixedModifier: Node? = null
+    var localModifier: PklNode? = null
+    var abstractModifier: PklNode? = null
+    var openModifier: PklNode? = null
+    var hiddenModifier: PklNode? = null
+    var fixedModifier: PklNode? = null
 
     for (modifier in node.modifiers!!) {
       when (modifier.type) {

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
@@ -17,14 +17,14 @@ package org.pkl.lsp.analyzers
 
 import org.pkl.lsp.ErrorMessages
 import org.pkl.lsp.Project
-import org.pkl.lsp.ast.Node
 import org.pkl.lsp.ast.PklMethod
 import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.PklProperty
 
 class ModuleMemberAnalyzer(project: Project) : Analyzer(project) {
 
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
     when (node) {
       is PklProperty -> {
         val isAmends = node.enclosingModule?.isAmend ?: false

--- a/src/main/kotlin/org/pkl/lsp/analyzers/PklDiagnostic.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/PklDiagnostic.kt
@@ -18,13 +18,13 @@ package org.pkl.lsp.analyzers
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.pkl.lsp.LSPUtil.toRange
-import org.pkl.lsp.ast.Node
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.Span
 
 class PklDiagnostic(span: Span, message: String, severity: DiagnosticSeverity) :
   Diagnostic(span.toRange(), message, severity, "pkl") {
   constructor(
-    node: Node,
+    node: PklNode,
     message: String,
     severity: DiagnosticSeverity,
   ) : this(node.span, message, severity)

--- a/src/main/kotlin/org/pkl/lsp/analyzers/StringLiteralAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/StringLiteralAnalyzer.kt
@@ -16,10 +16,10 @@
 package org.pkl.lsp.analyzers
 
 import org.pkl.lsp.Project
-import org.pkl.lsp.ast.Node
+import org.pkl.lsp.ast.PklNode
 
 class StringLiteralAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
     TODO("Not yet implemented")
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/SyntaxAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/SyntaxAnalyzer.kt
@@ -17,10 +17,10 @@ package org.pkl.lsp.analyzers
 
 import org.pkl.lsp.ErrorMessages
 import org.pkl.lsp.Project
-import org.pkl.lsp.ast.Node
+import org.pkl.lsp.ast.PklNode
 
 class SyntaxAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: Node, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
 
     val del = node.checkClosingDelimiter()
     if (del != null) {

--- a/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
@@ -22,9 +22,9 @@ import org.pkl.lsp.Project
 
 class PklQualifiedIdentifierImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: QualifiedIdentifierContext,
-) : AbstractNode(project, parent, ctx), PklQualifiedIdentifier {
+) : AbstractPklNode(project, parent, ctx), PklQualifiedIdentifier {
   override val identifiers: List<Terminal> by lazy { terminals }
   override val fullName: String by lazy { text }
 
@@ -35,9 +35,9 @@ class PklQualifiedIdentifierImpl(
 
 class PklStringConstantImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: StringConstantContext,
-) : AbstractNode(project, parent, ctx), PklStringConstant {
+) : AbstractPklNode(project, parent, ctx), PklStringConstant {
   override val value: String by lazy { text }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {

--- a/src/main/kotlin/org/pkl/lsp/ast/ClassMemberCache.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ClassMemberCache.kt
@@ -43,7 +43,7 @@ class ClassMemberCache(
   }
 
   private fun doVisit(
-    members: Map<String, Node>,
+    members: Map<String, PklNode>,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<*>,
   ): Boolean {

--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -28,9 +28,9 @@ import org.pkl.lsp.type.computeThisType
 
 class PklThisExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ThisExprContext,
-) : AbstractNode(project, parent, ctx), PklThisExpr {
+) : AbstractPklNode(project, parent, ctx), PklThisExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitThisExpr(this)
   }
@@ -38,9 +38,9 @@ class PklThisExprImpl(
 
 class PklOuterExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: OuterExprContext,
-) : AbstractNode(project, parent, ctx), PklOuterExpr {
+) : AbstractPklNode(project, parent, ctx), PklOuterExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitOuterExpr(this)
   }
@@ -48,9 +48,9 @@ class PklOuterExprImpl(
 
 class PklModuleExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ModuleExprContext,
-) : AbstractNode(project, parent, ctx), PklModuleExpr {
+) : AbstractPklNode(project, parent, ctx), PklModuleExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitModuleExpr(this)
   }
@@ -58,9 +58,9 @@ class PklModuleExprImpl(
 
 class PklNullLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: NullLiteralContext,
-) : AbstractNode(project, parent, ctx), PklNullLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklNullLiteralExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitNullLiteralExpr(this)
   }
@@ -68,9 +68,9 @@ class PklNullLiteralExprImpl(
 
 class PklTrueLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TrueLiteralContext,
-) : AbstractNode(project, parent, ctx), PklTrueLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklTrueLiteralExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitTrueLiteralExpr(this)
   }
@@ -78,9 +78,9 @@ class PklTrueLiteralExprImpl(
 
 class PklFalseLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: FalseLiteralContext,
-) : AbstractNode(project, parent, ctx), PklFalseLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklFalseLiteralExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitFalseLiteralExpr(this)
   }
@@ -88,9 +88,9 @@ class PklFalseLiteralExprImpl(
 
 class PklIntLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: IntLiteralContext,
-) : AbstractNode(project, parent, ctx), PklIntLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklIntLiteralExpr {
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitIntLiteralExpr(this)
@@ -99,9 +99,9 @@ class PklIntLiteralExprImpl(
 
 class PklFloatLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: FloatLiteralContext,
-) : AbstractNode(project, parent, ctx), PklFloatLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklFloatLiteralExpr {
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitFloatLiteralExpr(this)
@@ -110,9 +110,9 @@ class PklFloatLiteralExprImpl(
 
 class PklThrowExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ThrowExprContext,
-) : AbstractNode(project, parent, ctx), PklThrowExpr {
+) : AbstractPklNode(project, parent, ctx), PklThrowExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitThrowExpr(this)
   }
@@ -124,9 +124,9 @@ class PklThrowExprImpl(
 
 class PklTraceExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TraceExprContext,
-) : AbstractNode(project, parent, ctx), PklTraceExpr {
+) : AbstractPklNode(project, parent, ctx), PklTraceExpr {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -140,9 +140,9 @@ class PklTraceExprImpl(
 
 class PklImportExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ImportExprContext,
-) : AbstractNode(project, parent, ctx), PklImportExpr {
+) : AbstractPklNode(project, parent, ctx), PklImportExpr {
   override val isGlob: Boolean by lazy { ctx.IMPORT_GLOB() != null }
 
   override val moduleUri: PklModuleUri? by lazy { PklModuleUriImpl(project, this, ctx) }
@@ -158,9 +158,9 @@ class PklImportExprImpl(
 
 class PklReadExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ReadExprContext,
-) : AbstractNode(project, parent, ctx), PklReadExpr {
+) : AbstractPklNode(project, parent, ctx), PklReadExpr {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
   override val isNullable: Boolean by lazy { ctx.READ_OR_NULL() != null }
   override val isGlob: Boolean by lazy { ctx.READ_GLOB() != null }
@@ -176,9 +176,9 @@ class PklReadExprImpl(
 
 class PklUnqualifiedAccessExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: UnqualifiedAccessExprContext,
-) : AbstractNode(project, parent, ctx), PklUnqualifiedAccessExpr {
+) : AbstractPklNode(project, parent, ctx), PklUnqualifiedAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val memberNameText: String by lazy { identifier!!.text }
   override val argumentList: PklArgumentList? by lazy {
@@ -186,7 +186,7 @@ class PklUnqualifiedAccessExprImpl(
   }
   override val isNullSafeAccess: Boolean = false
 
-  override fun resolve(): Node? {
+  override fun resolve(): PklNode? {
     val base = project.pklBaseModule
     val visitor = ResolveVisitors.firstElementNamed(memberNameText, base)
     return resolve(base, null, mapOf(), visitor)
@@ -215,9 +215,9 @@ class PklUnqualifiedAccessExprImpl(
 
 class PklSingleLineStringLiteralImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: SingleLineStringLiteralContext,
-) : AbstractNode(project, parent, ctx), PklSingleLineStringLiteral {
+) : AbstractPklNode(project, parent, ctx), PklSingleLineStringLiteral {
   override val parts: List<SingleLineStringPart> by lazy {
     children.filterIsInstance<SingleLineStringPart>()
   }
@@ -229,9 +229,9 @@ class PklSingleLineStringLiteralImpl(
 
 class SingleLineStringPartImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   ctx: SingleLineStringPartContext,
-) : AbstractNode(project, parent, ctx), SingleLineStringPart {
+) : AbstractPklNode(project, parent, ctx), SingleLineStringPart {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -241,9 +241,9 @@ class SingleLineStringPartImpl(
 
 class PklMultiLineStringLiteralImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: MultiLineStringLiteralContext,
-) : AbstractNode(project, parent, ctx), PklMultiLineStringLiteral {
+) : AbstractPklNode(project, parent, ctx), PklMultiLineStringLiteral {
   override val parts: List<MultiLineStringPart> by lazy {
     children.filterIsInstance<MultiLineStringPart>()
   }
@@ -255,9 +255,9 @@ class PklMultiLineStringLiteralImpl(
 
 class MultiLineStringPartImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   ctx: MultiLineStringPartContext,
-) : AbstractNode(project, parent, ctx), MultiLineStringPart {
+) : AbstractPklNode(project, parent, ctx), MultiLineStringPart {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -267,9 +267,9 @@ class MultiLineStringPartImpl(
 
 class PklNewExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: NewExprContext,
-) : AbstractNode(project, parent, ctx), PklNewExpr {
+) : AbstractPklNode(project, parent, ctx), PklNewExpr {
   override val type: PklType? by lazy { children.firstInstanceOf<PklType>() }
   override val objectBody: PklObjectBody? by lazy { children.firstInstanceOf<PklObjectBody>() }
 
@@ -280,9 +280,9 @@ class PklNewExprImpl(
 
 class PklAmendExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: AmendExprContext,
-) : AbstractNode(project, parent, ctx), PklAmendExpr {
+) : AbstractPklNode(project, parent, ctx), PklAmendExpr {
   override val parentExpr: PklExpr by lazy { children.firstInstanceOf<PklExpr>()!! }
   override val objectBody: PklObjectBody by lazy { children.firstInstanceOf<PklObjectBody>()!! }
 
@@ -293,9 +293,9 @@ class PklAmendExprImpl(
 
 class PklSuperAccessExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: SuperAccessExprContext,
-) : AbstractNode(project, parent, ctx), PklSuperAccessExpr {
+) : AbstractPklNode(project, parent, ctx), PklSuperAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val memberNameText: String by lazy { identifier!!.text }
   override val isNullSafeAccess: Boolean = false
@@ -303,7 +303,7 @@ class PklSuperAccessExprImpl(
     children.firstInstanceOf<PklArgumentList>()
   }
 
-  override fun resolve(): Node? {
+  override fun resolve(): PklNode? {
     val base = project.pklBaseModule
     val visitor = ResolveVisitors.firstElementNamed(memberNameText, base)
     return resolve(base, null, mapOf(), visitor)
@@ -329,9 +329,9 @@ class PklSuperAccessExprImpl(
 
 class PklSuperSubscriptExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: SuperSubscriptExprContext,
-) : AbstractNode(project, parent, ctx), PklSuperSubscriptExpr {
+) : AbstractPklNode(project, parent, ctx), PklSuperSubscriptExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitSuperSubscriptExpr(this)
   }
@@ -343,9 +343,9 @@ class PklSuperSubscriptExprImpl(
 
 class PklQualifiedAccessExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: QualifiedAccessExprContext,
-) : AbstractNode(project, parent, ctx), PklQualifiedAccessExpr {
+) : AbstractPklNode(project, parent, ctx), PklQualifiedAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val memberNameText: String by lazy { identifier!!.text }
   override val isNullSafeAccess: Boolean by lazy { ctx.QDOT() != null }
@@ -354,7 +354,7 @@ class PklQualifiedAccessExprImpl(
   }
   override val receiverExpr: PklExpr by lazy { children.firstInstanceOf<PklExpr>()!! }
 
-  override fun resolve(): Node? {
+  override fun resolve(): PklNode? {
     val base = project.pklBaseModule
     val visitor = ResolveVisitors.firstElementNamed(memberNameText, base)
     // TODO: check if receiver is `module`
@@ -378,9 +378,9 @@ class PklQualifiedAccessExprImpl(
 
 class PklSubscriptExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: SubscriptExprContext,
-) : AbstractNode(project, parent, ctx), PklSubscriptExpr {
+) : AbstractPklNode(project, parent, ctx), PklSubscriptExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -396,9 +396,9 @@ class PklSubscriptExprImpl(
 
 class PklNonNullExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: NonNullExprContext,
-) : AbstractNode(project, parent, ctx), PklNonNullExpr {
+) : AbstractPklNode(project, parent, ctx), PklNonNullExpr {
   override val expr: PklExpr by lazy { children.firstInstanceOf<PklExpr>()!! }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -408,9 +408,9 @@ class PklNonNullExprImpl(
 
 class PklUnaryMinusExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: UnaryMinusExprContext,
-) : AbstractNode(project, parent, ctx), PklUnaryMinusExpr {
+) : AbstractPklNode(project, parent, ctx), PklUnaryMinusExpr {
   override val expr: PklExpr by lazy { ctx.expr().toNode(project, this) as PklExpr }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -420,9 +420,9 @@ class PklUnaryMinusExprImpl(
 
 class PklLogicalNotExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: LogicalNotExprContext,
-) : AbstractNode(project, parent, ctx), PklLogicalNotExpr {
+) : AbstractPklNode(project, parent, ctx), PklLogicalNotExpr {
   override val expr: PklExpr by lazy { ctx.expr().toNode(project, this) as PklExpr }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -432,9 +432,9 @@ class PklLogicalNotExprImpl(
 
 class PklAdditiveExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: AdditiveExprContext,
-) : AbstractNode(project, parent, ctx), PklAdditiveExpr {
+) : AbstractPklNode(project, parent, ctx), PklAdditiveExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -446,9 +446,9 @@ class PklAdditiveExprImpl(
 
 class PklMultiplicativeExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: MultiplicativeExprContext,
-) : AbstractNode(project, parent, ctx), PklMultiplicativeExpr {
+) : AbstractPklNode(project, parent, ctx), PklMultiplicativeExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -460,9 +460,9 @@ class PklMultiplicativeExprImpl(
 
 class PklComparisonExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ComparisonExprContext,
-) : AbstractNode(project, parent, ctx), PklComparisonExpr {
+) : AbstractPklNode(project, parent, ctx), PklComparisonExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -474,9 +474,9 @@ class PklComparisonExprImpl(
 
 class PklEqualityExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: EqualityExprContext,
-) : AbstractNode(project, parent, ctx), PklEqualityExpr {
+) : AbstractPklNode(project, parent, ctx), PklEqualityExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -488,9 +488,9 @@ class PklEqualityExprImpl(
 
 class PklExponentiationExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ExponentiationExprContext,
-) : AbstractNode(project, parent, ctx), PklExponentiationExpr {
+) : AbstractPklNode(project, parent, ctx), PklExponentiationExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -502,9 +502,9 @@ class PklExponentiationExprImpl(
 
 class PklLogicalAndExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: LogicalAndExprContext,
-) : AbstractNode(project, parent, ctx), PklLogicalAndExpr {
+) : AbstractPklNode(project, parent, ctx), PklLogicalAndExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -516,9 +516,9 @@ class PklLogicalAndExprImpl(
 
 class PklLogicalOrExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: LogicalOrExprContext,
-) : AbstractNode(project, parent, ctx), PklLogicalOrExpr {
+) : AbstractPklNode(project, parent, ctx), PklLogicalOrExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -530,9 +530,9 @@ class PklLogicalOrExprImpl(
 
 class PklNullCoalesceExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: NullCoalesceExprContext,
-) : AbstractNode(project, parent, ctx), PklNullCoalesceExpr {
+) : AbstractPklNode(project, parent, ctx), PklNullCoalesceExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -544,9 +544,9 @@ class PklNullCoalesceExprImpl(
 
 class PklTypeTestExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TypeTestExprContext,
-) : AbstractNode(project, parent, ctx), PklTypeTestExpr {
+) : AbstractPklNode(project, parent, ctx), PklTypeTestExpr {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
   override val operator: TypeTestOperator by lazy {
@@ -560,9 +560,9 @@ class PklTypeTestExprImpl(
 
 class PklPipeExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PipeExprContext,
-) : AbstractNode(project, parent, ctx), PklPipeExpr {
+) : AbstractPklNode(project, parent, ctx), PklPipeExpr {
   override val leftExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val rightExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
   override val operator: Terminal by lazy { terminals[0] }
@@ -574,9 +574,9 @@ class PklPipeExprImpl(
 
 class PklIfExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: IfExprContext,
-) : AbstractNode(project, parent, ctx), PklIfExpr {
+) : AbstractPklNode(project, parent, ctx), PklIfExpr {
   override val conditionExpr: PklExpr by lazy { ctx.c.toNode(project, this) as PklExpr }
   override val thenExpr: PklExpr by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val elseExpr: PklExpr by lazy { ctx.r.toNode(project, this) as PklExpr }
@@ -592,9 +592,9 @@ class PklIfExprImpl(
 
 class PklLetExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: LetExprContext,
-) : AbstractNode(project, parent, ctx), PklLetExpr {
+) : AbstractPklNode(project, parent, ctx), PklLetExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val varExpr: PklExpr? by lazy { ctx.l.toNode(project, this) as PklExpr }
   override val bodyExpr: PklExpr? by lazy { ctx.r.toNode(project, this) as PklExpr }
@@ -611,9 +611,9 @@ class PklLetExprImpl(
 
 class PklFunctionLiteralExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: FunctionLiteralContext,
-) : AbstractNode(project, parent, ctx), PklFunctionLiteralExpr {
+) : AbstractPklNode(project, parent, ctx), PklFunctionLiteralExpr {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
   override val parameterList: PklParameterList by lazy {
     children.firstInstanceOf<PklParameterList>()!!
@@ -626,9 +626,9 @@ class PklFunctionLiteralExprImpl(
 
 class PklParenthesizedExprImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ParenthesizedExprContext,
-) : AbstractNode(project, parent, ctx), PklParenthesizedExpr {
+) : AbstractPklNode(project, parent, ctx), PklParenthesizedExpr {
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -642,9 +642,9 @@ class PklParenthesizedExprImpl(
 
 class PklTypedIdentifierImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TypedIdentifierContext,
-) : AbstractNode(project, parent, ctx), PklTypedIdentifier {
+) : AbstractPklNode(project, parent, ctx), PklTypedIdentifier {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val typeAnnotation: PklTypeAnnotation? by lazy {
     children.firstInstanceOf<PklTypeAnnotation>()
@@ -657,9 +657,9 @@ class PklTypedIdentifierImpl(
 
 class PklParameterImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ParameterContext,
-) : AbstractNode(project, parent, ctx), PklParameter {
+) : AbstractPklNode(project, parent, ctx), PklParameter {
   override val isUnderscore: Boolean by lazy { ctx.UNDERSCORE() != null }
   override val typedIdentifier: PklTypedIdentifier? by lazy {
     children.firstInstanceOf<PklTypedIdentifier>()
@@ -673,9 +673,9 @@ class PklParameterImpl(
 
 class PklArgumentListImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ArgumentListContext,
-) : AbstractNode(project, parent, ctx), PklArgumentList {
+) : AbstractPklNode(project, parent, ctx), PklArgumentList {
   override val elements: List<PklExpr> by lazy { children.filterIsInstance<PklExpr>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleMemberCache.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleMemberCache.kt
@@ -65,7 +65,7 @@ private constructor(
     return if (isProperty) doVisit(typeDefsAndProperties, visitor) else doVisit(methods, visitor)
   }
 
-  private fun doVisit(members: Map<String, Node>, visitor: ResolveVisitor<*>): Boolean {
+  private fun doVisit(members: Map<String, PklNode>, visitor: ResolveVisitor<*>): Boolean {
     val exactName = visitor.exactName
     if (exactName != null) {
       return (visitor.visitIfNotNull(exactName, members[exactName], mapOf()))

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -25,7 +25,7 @@ class PklModuleImpl(
   override val ctx: PklParser.ModuleContext,
   override val uri: URI,
   override val virtualFile: VirtualFile,
-) : AbstractNode(virtualFile.project, null, ctx), PklModule {
+) : AbstractPklNode(virtualFile.project, null, ctx), PklModule {
   override val isAmend: Boolean by lazy {
     declaration?.moduleExtendsAmendsClause?.isAmend
       ?: declaration?.moduleHeader?.moduleExtendsAmendsClause?.isAmend
@@ -87,9 +87,9 @@ class PklModuleImpl(
 
 class PklAnnotationImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.AnnotationContext,
-) : AbstractNode(project, parent, ctx), PklAnnotation {
+) : AbstractPklNode(project, parent, ctx), PklAnnotation {
   override val type: PklType? by lazy { children.firstInstanceOf<PklType>() }
 
   override val typeName: PklTypeName? by lazy { (type as? PklDeclaredType)?.name }
@@ -103,9 +103,9 @@ class PklAnnotationImpl(
 
 class PklModuleHeaderImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ModuleHeaderContext,
-) : AbstractNode(project, parent, ctx), PklModuleHeader {
+) : AbstractPklNode(project, parent, ctx), PklModuleHeader {
   override val qualifiedIdentifier: PklQualifiedIdentifier? by lazy {
     getChild(PklQualifiedIdentifierImpl::class)
   }
@@ -129,9 +129,9 @@ class PklModuleHeaderImpl(
 
 class PklModuleDeclarationImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ModuleDeclContext,
-) : AbstractNode(project, parent, ctx), PklModuleDeclaration {
+) : AbstractPklNode(project, parent, ctx), PklModuleDeclaration {
 
   override val annotations: List<PklAnnotation> by lazy {
     ctx.annotation().map { PklAnnotationImpl(project, this, it) }
@@ -154,9 +154,9 @@ class PklModuleDeclarationImpl(
 
 class PklImportImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ImportClauseContext,
-) : AbstractNode(project, parent, ctx), PklImport {
+) : AbstractPklNode(project, parent, ctx), PklImport {
   override val identifier: Terminal? by lazy { ctx.Identifier()?.toTerminal(this) }
 
   override val isGlob: Boolean by lazy { ctx.IMPORT_GLOB() != null }
@@ -170,9 +170,9 @@ class PklImportImpl(
 
 class PklModuleExtendsAmendsClauseImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ModuleExtendsOrAmendsClauseContext,
-) : AbstractNode(project, parent, ctx), PklModuleExtendsAmendsClause {
+) : AbstractPklNode(project, parent, ctx), PklModuleExtendsAmendsClause {
   override val isAmend: Boolean
     get() = ctx.AMENDS() != null
 
@@ -188,9 +188,9 @@ class PklModuleExtendsAmendsClauseImpl(
 
 class PklClassImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ClazzContext,
-) : AbstractNode(project, parent, ctx), PklClass {
+) : AbstractPklNode(project, parent, ctx), PklClass {
   override val classHeader: PklClassHeader by lazy { getChild(PklClassHeaderImpl::class)!! }
 
   override val annotations: List<PklAnnotation>? by lazy { getChildren(PklAnnotationImpl::class) }
@@ -220,9 +220,9 @@ class PklClassImpl(
 
 class PklClassHeaderImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ClassHeaderContext,
-) : AbstractNode(project, parent, ctx), PklClassHeader {
+) : AbstractPklNode(project, parent, ctx), PklClassHeader {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
 
   override val modifiers: List<Terminal> by lazy { terminals.takeWhile { it.isModifier } }
@@ -240,9 +240,9 @@ class PklClassHeaderImpl(
 
 class PklClassBodyImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.ClassBodyContext,
-) : AbstractNode(project, parent, ctx), PklClassBody {
+) : AbstractPklNode(project, parent, ctx), PklClassBody {
   override val members: List<PklClassMember> by lazy { children.filterIsInstance<PklClassMember>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -256,9 +256,9 @@ class PklClassBodyImpl(
 
 class PklTypeParameterListImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.TypeParameterListContext,
-) : AbstractNode(project, parent, ctx), PklTypeParameterList {
+) : AbstractPklNode(project, parent, ctx), PklTypeParameterList {
   override val typeParameters: List<PklTypeParameter> by lazy {
     getChildren(PklTypeParameterImpl::class) ?: listOf()
   }
@@ -277,9 +277,9 @@ class PklTypeParameterListImpl(
 
 class PklTypeParameterImpl(
   override val project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: PklParser.TypeParameterContext,
-) : AbstractNode(project, parent, ctx), PklTypeParameter {
+) : AbstractPklNode(project, parent, ctx), PklTypeParameter {
   override val variance: Variance? by lazy {
     if (ctx.IN() != null) Variance.IN else if (ctx.OUT() != null) Variance.OUT else null
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -20,8 +20,11 @@ import org.antlr.v4.runtime.tree.ParseTree
 import org.pkl.lsp.*
 import org.pkl.lsp.LSPUtil.firstInstanceOf
 
-class PklModuleUriImpl(project: Project, override val parent: Node, override val ctx: ParseTree) :
-  AbstractNode(project, parent, ctx), PklModuleUri {
+class PklModuleUriImpl(
+  project: Project,
+  override val parent: PklNode,
+  override val ctx: ParseTree,
+) : AbstractPklNode(project, parent, ctx), PklModuleUri {
   override val stringConstant: PklStringConstant by lazy {
     children.firstInstanceOf<PklStringConstant>()!!
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
@@ -22,10 +22,10 @@ import org.pkl.lsp.Project
 
 class TerminalImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TerminalNode,
   override val type: TokenType,
-) : AbstractNode(project, parent, ctx), Terminal {
+) : AbstractPklNode(project, parent, ctx), Terminal {
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitTerminal(this)
@@ -37,7 +37,7 @@ val Terminal.isModifier: Boolean
     return modifierTypes.contains(type)
   }
 
-fun TerminalNode.toTerminal(parent: Node): Terminal? {
+fun TerminalNode.toTerminal(parent: PklNode): Terminal? {
   val tokenType =
     when (symbol.type) {
       PklParser.ABSTRACT -> TokenType.ABSTRACT

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -23,9 +23,9 @@ import org.pkl.lsp.Project
 
 class PklTypeAnnotationImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   ctx: TypeAnnotationContext,
-) : AbstractNode(project, parent, ctx), PklTypeAnnotation {
+) : AbstractPklNode(project, parent, ctx), PklTypeAnnotation {
   override val type: PklType? by lazy { children.firstInstanceOf<PklType>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -33,22 +33,22 @@ class PklTypeAnnotationImpl(
   }
 }
 
-class PklUnknownTypeImpl(project: Project, override val parent: Node, ctx: UnknownTypeContext) :
-  AbstractNode(project, parent, ctx), PklUnknownType {
+class PklUnknownTypeImpl(project: Project, override val parent: PklNode, ctx: UnknownTypeContext) :
+  AbstractPklNode(project, parent, ctx), PklUnknownType {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitUnknownType(this)
   }
 }
 
-class PklNothingTypeImpl(project: Project, override val parent: Node, ctx: NothingTypeContext) :
-  AbstractNode(project, parent, ctx), PklNothingType {
+class PklNothingTypeImpl(project: Project, override val parent: PklNode, ctx: NothingTypeContext) :
+  AbstractPklNode(project, parent, ctx), PklNothingType {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitNothingType(this)
   }
 }
 
-class PklModuleTypeImpl(project: Project, override val parent: Node, ctx: ModuleTypeContext) :
-  AbstractNode(project, parent, ctx), PklModuleType {
+class PklModuleTypeImpl(project: Project, override val parent: PklNode, ctx: ModuleTypeContext) :
+  AbstractPklNode(project, parent, ctx), PklModuleType {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitModuleType(this)
   }
@@ -56,9 +56,9 @@ class PklModuleTypeImpl(project: Project, override val parent: Node, ctx: Module
 
 class PklStringLiteralTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   ctx: StringLiteralTypeContext,
-) : AbstractNode(project, parent, ctx), PklStringLiteralType {
+) : AbstractPklNode(project, parent, ctx), PklStringLiteralType {
   override val stringConstant: PklStringConstant by lazy {
     children.firstInstanceOf<PklStringConstant>()!!
   }
@@ -70,9 +70,9 @@ class PklStringLiteralTypeImpl(
 
 class PklDeclaredTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: DeclaredTypeContext,
-) : AbstractNode(project, parent, ctx), PklDeclaredType {
+) : AbstractPklNode(project, parent, ctx), PklDeclaredType {
   override val name: PklTypeName by lazy {
     toTypeName(children.firstInstanceOf<PklQualifiedIdentifier>()!!)
   }
@@ -92,9 +92,9 @@ class PklDeclaredTypeImpl(
 
 class PklTypeArgumentListImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: TypeArgumentListContext,
-) : AbstractNode(project, parent, ctx), PklTypeArgumentList {
+) : AbstractPklNode(project, parent, ctx), PklTypeArgumentList {
   override val types: List<PklType> by lazy { children.filterIsInstance<PklType>() }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -111,9 +111,9 @@ class PklTypeArgumentListImpl(
 
 class PklParenthesizedTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ParenthesizedTypeContext,
-) : AbstractNode(project, parent, ctx), PklParenthesizedType {
+) : AbstractPklNode(project, parent, ctx), PklParenthesizedType {
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -125,8 +125,11 @@ class PklParenthesizedTypeImpl(
   }
 }
 
-class PklNullableTypeImpl(project: Project, override val parent: Node, ctx: NullableTypeContext) :
-  AbstractNode(project, parent, ctx), PklNullableType {
+class PklNullableTypeImpl(
+  project: Project,
+  override val parent: PklNode,
+  ctx: NullableTypeContext,
+) : AbstractPklNode(project, parent, ctx), PklNullableType {
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -136,9 +139,9 @@ class PklNullableTypeImpl(project: Project, override val parent: Node, ctx: Null
 
 class PklConstrainedTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: ConstrainedTypeContext,
-) : AbstractNode(project, parent, ctx), PklConstrainedType {
+) : AbstractPklNode(project, parent, ctx), PklConstrainedType {
   override val type: PklType? by lazy { children.firstInstanceOf<PklType>() }
   override val exprs: List<PklExpr> by lazy { children.filterIsInstance<PklExpr>() }
 
@@ -154,8 +157,8 @@ class PklConstrainedTypeImpl(
   }
 }
 
-class PklUnionTypeImpl(project: Project, override val parent: Node, ctx: UnionTypeContext) :
-  AbstractNode(project, parent, ctx), PklUnionType {
+class PklUnionTypeImpl(project: Project, override val parent: PklNode, ctx: UnionTypeContext) :
+  AbstractPklNode(project, parent, ctx), PklUnionType {
   override val typeList: List<PklType> by lazy { children.filterIsInstance<PklType>() }
   override val leftType: PklType by lazy { typeList[0] }
   override val rightType: PklType by lazy { typeList[1] }
@@ -167,9 +170,9 @@ class PklUnionTypeImpl(project: Project, override val parent: Node, ctx: UnionTy
 
 class PklFunctionTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   override val ctx: FunctionTypeContext,
-) : AbstractNode(project, parent, ctx), PklFunctionType {
+) : AbstractPklNode(project, parent, ctx), PklFunctionType {
   override val parameterList: List<PklType> by lazy {
     children.filterIsInstance<PklType>().dropLast(1)
   }
@@ -189,9 +192,9 @@ class PklFunctionTypeImpl(
 
 class PklDefaultUnionTypeImpl(
   project: Project,
-  override val parent: Node,
+  override val parent: PklNode,
   ctx: DefaultUnionTypeContext,
-) : AbstractNode(project, parent, ctx), PklDefaultUnionType {
+) : AbstractPklNode(project, parent, ctx), PklDefaultUnionType {
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -199,8 +202,8 @@ class PklDefaultUnionTypeImpl(
   }
 }
 
-class PklTypeAliasImpl(project: Project, override val parent: Node?, ctx: TypeAliasContext) :
-  AbstractNode(project, parent, ctx), PklTypeAlias {
+class PklTypeAliasImpl(project: Project, override val parent: PklNode?, ctx: TypeAliasContext) :
+  AbstractPklNode(project, parent, ctx), PklTypeAlias {
   override val typeAliasHeader: PklTypeAliasHeader by lazy {
     children.firstInstanceOf<PklTypeAliasHeader>()!!
   }
@@ -219,9 +222,9 @@ class PklTypeAliasImpl(project: Project, override val parent: Node?, ctx: TypeAl
 
 class PklTypeAliasHeaderImpl(
   project: Project,
-  override val parent: Node?,
+  override val parent: PklNode?,
   ctx: TypeAliasHeaderContext,
-) : AbstractNode(project, parent, ctx), PklTypeAliasHeader {
+) : AbstractPklNode(project, parent, ctx), PklTypeAliasHeader {
   override val modifiers: List<Terminal>? by lazy { terminals.takeWhile { it.isModifier } }
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val typeParameterList: PklTypeParameterList? by lazy {
@@ -237,7 +240,7 @@ class PklTypeNameImpl(
   project: Project,
   ident: PklQualifiedIdentifier,
   override val ctx: QualifiedIdentifierContext,
-) : AbstractNode(project, ident.parent, ctx), PklTypeName {
+) : AbstractPklNode(project, ident.parent, ctx), PklTypeName {
   override val moduleName: PklModuleName? by lazy {
     // if there's only 1 identifier it's not qualified, therefore, there's no module name
     if (ctx.Identifier().size > 1) {
@@ -255,10 +258,10 @@ class PklTypeNameImpl(
 
 class PklSimpleTypeNameImpl(
   project: Project,
-  parent: Node,
+  parent: PklNode,
   terminal: Terminal,
   override val ctx: ParseTree,
-) : AbstractNode(project, parent, ctx), PklSimpleTypeName {
+) : AbstractPklNode(project, parent, ctx), PklSimpleTypeName {
   override val identifier: Terminal? by lazy { terminal }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
@@ -268,10 +271,10 @@ class PklSimpleTypeNameImpl(
 
 class PklModuleNameImpl(
   project: Project,
-  parent: Node,
+  parent: PklNode,
   terminal: Terminal,
   override val ctx: ParseTree,
-) : AbstractNode(project, parent, ctx), PklModuleName {
+) : AbstractPklNode(project, parent, ctx), PklModuleName {
   override val identifier: Terminal? by lazy { terminal }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {

--- a/src/main/kotlin/org/pkl/lsp/features/CompletionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/CompletionFeature.kt
@@ -55,7 +55,7 @@ class CompletionFeature(private val server: PklLSPServer, project: Project) : Co
     return server.builder().runningBuild(params.textDocument.uri).thenApply(::run)
   }
 
-  private fun Node.resolveCompletion(line: Int, col: Int): List<CompletionItem>? {
+  private fun PklNode.resolveCompletion(line: Int, col: Int): List<CompletionItem>? {
     val node = resolveReference(line, col) ?: return null
     val showTypes = parentOfType<PklNewExpr>() != null
     val module = if (this is PklModule) this else enclosingModule
@@ -81,7 +81,7 @@ class CompletionFeature(private val server: PklLSPServer, project: Project) : Co
     }
   }
 
-  private fun Node.complete(showTypes: Boolean, sourceModule: PklModule?): List<CompletionItem> =
+  private fun PklNode.complete(showTypes: Boolean, sourceModule: PklModule?): List<CompletionItem> =
     when (this) {
       is PklModule -> complete(showTypes, sourceModule)
       is PklClass -> complete()

--- a/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
@@ -45,7 +45,7 @@ class GoToDefinitionFeature(private val server: PklLSPServer, project: Project) 
     return server.builder().runningBuild(params.textDocument.uri).thenApply(::run)
   }
 
-  private fun resolveDeclaration(originalNode: Node, line: Int, col: Int): Location? {
+  private fun resolveDeclaration(originalNode: PklNode, line: Int, col: Int): Location? {
     val node = originalNode.resolveReference(line, col) ?: return null
     return when (node) {
       is PklThisExpr ->
@@ -54,7 +54,7 @@ class GoToDefinitionFeature(private val server: PklLSPServer, project: Project) 
     }
   }
 
-  private fun Node.toLocation(): Location {
+  private fun PklNode.toLocation(): Location {
     return Location(toURIString(), beginningSpan().toRange())
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
@@ -40,7 +40,7 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     return server.builder().runningBuild(params.textDocument.uri).thenApply(::run)
   }
 
-  private fun resolveHover(originalNode: Node, line: Int, col: Int): String? {
+  private fun resolveHover(originalNode: PklNode, line: Int, col: Int): String? {
     val node = originalNode.resolveReference(line, col) ?: return null
     val base = project.pklBaseModule
     if (node !== originalNode) return node.toMarkdown(originalNode)
@@ -80,7 +80,7 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     }
   }
 
-  private fun Node.render(originalNode: Node?): String =
+  private fun PklNode.render(originalNode: PklNode?): String =
     when (this) {
       is PklProperty ->
         buildString {
@@ -197,8 +197,8 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
   private fun renderTypeAnnotation(
     name: String?,
     type: PklType?,
-    node: Node,
-    originalNode: Node?,
+    node: PklNode,
+    originalNode: PklNode?,
   ): String? {
     if (name == null) return null
     return buildString {
@@ -252,7 +252,7 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     }
   }
 
-  private fun Node.toMarkdown(originalNode: Node?): String {
+  private fun PklNode.toMarkdown(originalNode: PklNode?): String {
     val markdown = render(originalNode)
     return when {
       this is PklModule && declaration != null -> showDocCommentAndModule(declaration!!, markdown)
@@ -260,7 +260,7 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     }
   }
 
-  private fun showDocCommentAndModule(node: Node?, text: String): String {
+  private fun showDocCommentAndModule(node: PklNode?, text: String): String {
     val markdown = "```pkl\n$text\n```"
     val withDoc =
       if (node is PklDocCommentOwner) {

--- a/src/main/kotlin/org/pkl/lsp/resolvers/ResolveVisitors.kt
+++ b/src/main/kotlin/org/pkl/lsp/resolvers/ResolveVisitors.kt
@@ -26,7 +26,7 @@ interface ResolveVisitor<R> {
    * Note: [element] may be of type [PklImport], which visitors need to `resolve()` on their own if
    * so desired.
    */
-  fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean
+  fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean
 
   val result: R
 
@@ -41,7 +41,7 @@ interface ResolveVisitor<R> {
 
 fun ResolveVisitor<*>.visitIfNotNull(
   name: String?,
-  element: Node?,
+  element: PklNode?,
   bindings: TypeParameterBindings,
 ): Boolean = if (name != null && element != null) visit(name, element, bindings) else true
 
@@ -66,7 +66,7 @@ object ResolveVisitors {
     resolveTypeParamsInParamTypes: Boolean = true,
   ): ResolveVisitor<List<Type>?> =
     object : ResolveVisitor<List<Type>?> {
-      override fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean {
+      override fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean {
         if (name != expectedName) return true
 
         when (element) {
@@ -130,7 +130,7 @@ object ResolveVisitors {
         return false
       }
 
-      override fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean {
+      override fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean {
         if (name != elementName) return true
 
         val type =
@@ -283,9 +283,9 @@ object ResolveVisitors {
     expectedName: String,
     base: PklBaseModule,
     resolveImports: Boolean = true,
-  ): ResolveVisitor<Node?> =
-    object : ResolveVisitor<Node?> {
-      override fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean {
+  ): ResolveVisitor<PklNode?> =
+    object : ResolveVisitor<PklNode?> {
+      override fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean {
         if (name != expectedName) return true
 
         when {
@@ -309,7 +309,7 @@ object ResolveVisitors {
         return false
       }
 
-      override var result: Node? = null
+      override var result: PklNode? = null
 
       override val exactName: String
         get() = expectedName
@@ -320,9 +320,9 @@ object ResolveVisitors {
     expectedName: String,
     base: PklBaseModule,
     resolveImports: Boolean = true,
-  ): ResolveVisitor<List<Node>> =
-    object : ResolveVisitor<List<Node>> {
-      override fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean {
+  ): ResolveVisitor<List<PklNode>> =
+    object : ResolveVisitor<List<PklNode>> {
+      override fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean {
         if (name != expectedName) return true
 
         when {
@@ -346,7 +346,7 @@ object ResolveVisitors {
         return true
       }
 
-      override var result: MutableList<Node> = mutableListOf()
+      override var result: MutableList<PklNode> = mutableListOf()
 
       override val exactName: String
         get() = expectedName
@@ -377,7 +377,7 @@ fun <R> ResolveVisitor<R>.withoutShadowedElements(): ResolveVisitor<R> =
     private val visitedProperties = mutableSetOf<String>()
     private val visitedMethods = mutableSetOf<String>()
 
-    override fun visit(name: String, element: Node, bindings: TypeParameterBindings): Boolean {
+    override fun visit(name: String, element: PklNode, bindings: TypeParameterBindings): Boolean {
       return when (element) {
         is PklMethod ->
           if (visitedMethods.add(name)) {

--- a/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
+++ b/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
@@ -31,7 +31,7 @@ object Resolvers {
   }
 
   fun <R> resolveQualifiedTypeName(
-    position: Node,
+    position: PklNode,
     moduleName: String,
     // receives elements of type PklTypeDef, PklImport, and PklTypeParameter
     visitor: ResolveVisitor<R>,
@@ -52,7 +52,7 @@ object Resolvers {
   }
 
   fun <R> resolveUnqualifiedTypeName(
-    position: Node,
+    position: PklNode,
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     // receives elements of type PklTypeDef, PklImport, and PklTypeParameter
@@ -97,7 +97,7 @@ object Resolvers {
 
   /** Note: For resolving [PklAccessExpr], use [PklAccessExpr.resolve] instead. */
   fun <R> resolveUnqualifiedAccess(
-    position: Node,
+    position: PklNode,
     // optionally provide the type of `this` at [position]
     // to avoid its recomputation in case it is needed
     thisType: Type?,
@@ -111,7 +111,7 @@ object Resolvers {
   }
 
   fun <R> resolveUnqualifiedAccess(
-    position: Node,
+    position: PklNode,
     // optionally provide the type of `this` at [position]
     // to avoid its recomputation in case it is needed
     thisType: Type?,
@@ -131,7 +131,7 @@ object Resolvers {
   }
 
   fun <R> resolveUnqualifiedAccessAndLookupMode(
-    position: Node,
+    position: PklNode,
     // optionally provide the type of `this` at [position]
     // to avoid its recomputation in case it is needed
     thisType: Type?,
@@ -175,7 +175,7 @@ object Resolvers {
   }
 
   private fun <R> resolveUnqualifiedVariableAccess(
-    position: Node,
+    position: PklNode,
     thisType: Type?,
     base: PklBaseModule,
     bindings: TypeParameterBindings,
@@ -183,7 +183,7 @@ object Resolvers {
     visitor: ResolveVisitor<R>,
   ): Pair<R, LookupMode> {
 
-    var element: Node? = position
+    var element: PklNode? = position
     var skipNextObjectBody = false
 
     while (element != null) {
@@ -477,14 +477,14 @@ object Resolvers {
   }
 
   private fun <R> resolveUnqualifiedMethodAccess(
-    position: Node,
+    position: PklNode,
     thisType: Type?,
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<R>,
   ): Pair<R, LookupMode> {
 
-    var element: Node? = position
+    var element: PklNode? = position
 
     while (element != null) {
       when (element) {

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
@@ -23,12 +23,12 @@ import org.pkl.lsp.resolvers.Resolvers
 
 private val value = Any()
 
-fun Node?.computeResolvedImportType(
+fun PklNode?.computeResolvedImportType(
   base: PklBaseModule,
   bindings: TypeParameterBindings,
   preserveUnboundTypeVars: Boolean = false,
   canInferExprBody: Boolean = true,
-  cache: IdentityHashMap<Node, Any> = IdentityHashMap(),
+  cache: IdentityHashMap<PklNode, Any> = IdentityHashMap(),
 ): Type {
   if (this == null) return Type.Unknown
   if (cache.containsKey(this)) return Type.Unknown

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
@@ -20,9 +20,9 @@ import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.resolvers.ResolveVisitors
 
-private val cache: IdentityHashMap<Node, Type> = IdentityHashMap()
+private val cache: IdentityHashMap<PklNode, Type> = IdentityHashMap()
 
-fun Node?.computeExprType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
+fun PklNode?.computeExprType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
   return when {
     this == null || this !is PklExpr -> Type.Unknown
     // TODO: properly invalidate the cache
@@ -40,7 +40,7 @@ fun Node?.computeExprType(base: PklBaseModule, bindings: TypeParameterBindings):
   }
 }
 
-private fun Node.doComputeExprType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
+private fun PklNode.doComputeExprType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
   return when (this) {
     is PklUnqualifiedAccessExpr -> {
       val visitor =

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeThisType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeThisType.kt
@@ -18,8 +18,8 @@ package org.pkl.lsp.type
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.ast.*
 
-fun Node.computeThisType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
-  var element: Node? = this
+fun PklNode.computeThisType(base: PklBaseModule, bindings: TypeParameterBindings): Type {
+  var element: PklNode? = this
   var memberPredicateExprSeen = false
   var objectBodySeen = false
   var skipNextObjectBody = false

--- a/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt
@@ -47,7 +47,7 @@ fun PklExpr?.inferExprTypeFromContext(
 private fun PklExpr?.doInferExprTypeFromContext(
   base: PklBaseModule,
   bindings: TypeParameterBindings,
-  parent: Node?,
+  parent: PklNode?,
   resolveTypeParamsInParamTypes: Boolean = true,
   canInferParentExpr: Boolean = true,
 ): Type {

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -194,7 +194,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
 
   override fun toString(): String = render()
 
-  fun getNode(project: Project): Node? =
+  fun getNode(project: Project): PklNode? =
     when (this) {
       is Class -> ctx
       is Module -> ctx

--- a/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
@@ -22,9 +22,9 @@ import org.eclipse.lsp4j.*
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.io.TempDir
 import org.pkl.core.parser.Parser
-import org.pkl.lsp.ast.Node
 import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklModuleImpl
+import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.findBySpan
 
 abstract class LSPTestBase {
@@ -85,7 +85,7 @@ abstract class LSPTestBase {
    * Issues a goto definition command on the position underneath the cursor, and returns the
    * resolved nodes.
    */
-  protected fun goToDefinition(): List<Node> {
+  protected fun goToDefinition(): List<PklNode> {
     if (fileInFocus == null)
       throw IllegalStateException(
         "No active Pkl module found in editor. Call `createPklFile` first."


### PR DESCRIPTION
Renaming the `Node` class to `PklNode` because:

* Tree sitter has a `Node` class that we use under ours, so it gets confusing reading code and not knowing what `Node` means
* Every instance of `Node` already has a `Pkl` prefix, so this brings `Node` in line with the rest of the AST