### PR TITLE
Add project support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,7 @@ java {
 val pklCli: Configuration by configurations.creating
 
 dependencies {
+  implementation(kotlin("reflect"))
   implementation(libs.antlr)
   implementation(libs.clikt)
   implementation(libs.pklCore)

--- a/src/main/kotlin/org/pkl/lsp/Builder.kt
+++ b/src/main/kotlin/org/pkl/lsp/Builder.kt
@@ -34,11 +34,47 @@ import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklModuleImpl
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.Span
+import org.pkl.lsp.services.PackageEventType
+import org.pkl.lsp.services.ProjectEventType
+import org.pkl.lsp.services.packageTopic
+import org.pkl.lsp.services.projectTopic
 
 class Builder(private val server: PklLSPServer, project: Project) : Component(project) {
   private val runningBuild: MutableMap<String, CompletableFuture<PklModule?>> = mutableMapOf()
 
+  private val buildCache: MutableMap<URI, PklModule> = ConcurrentHashMap()
+
+  val diagnosticsCache: MutableMap<URI, List<PklDiagnostic>> = ConcurrentHashMap()
+
   private val parser = Parser()
+
+  private val openFiles: MutableMap<URI, Boolean> = ConcurrentHashMap()
+
+  override fun initialize() {
+    project.messageBus.subscribe(textDocumentTopic) { event ->
+      if (event.type == TextDocumentEventType.OPENED) {
+        openFiles[event.file] = true
+      } else if (event.type == TextDocumentEventType.CLOSED) {
+        openFiles[event.file] = false
+      }
+    }
+    project.messageBus.subscribe(packageTopic) { event ->
+      if (event.type != PackageEventType.PACKAGE_DOWNLOADED) return@subscribe
+      openFiles.forEach { (uri, _) ->
+        val virtualFile = project.virtualFileManager.get(uri) ?: return@forEach
+        // refresh diagnostics for every module
+        project.builder.requestBuild(uri, virtualFile)
+      }
+    }
+    project.messageBus.subscribe(projectTopic) { event ->
+      if (event.type != ProjectEventType.PROJECTS_SYNCED) return@subscribe
+      openFiles.forEach { (uri, _) ->
+        val virtualFile = project.virtualFileManager.get(uri) ?: return@forEach
+        // refresh diagnostics for every module
+        project.builder.requestBuild(uri, virtualFile)
+      }
+    }
+  }
 
   private val analyzers: List<Analyzer> =
     listOf(
@@ -49,27 +85,54 @@ class Builder(private val server: PklLSPServer, project: Project) : Component(pr
       ModuleMemberAnalyzer(project),
     )
 
-  fun runningBuild(uri: String): CompletableFuture<PklModule?> =
-    runningBuild[uri] ?: CompletableFuture.supplyAsync(::noop)
+  fun runningBuild(uri: String): CompletableFuture<PklModule?> {
+    val effectiveUri = URI(uri).effectiveUri ?: return CompletableFuture.completedFuture(null)
+    return runningBuild[effectiveUri.toString()] ?: CompletableFuture.completedFuture(null)
+  }
 
   fun requestBuild(
     uri: URI,
     vfile: VirtualFile,
     fileContents: String? = null,
   ): CompletableFuture<PklModule?> {
-    val build = CompletableFuture.supplyAsync { build(uri, vfile, fileContents) }
-    runningBuild[uri.toString()] = build
+    val effectiveUri = uri.effectiveUri
+    if (effectiveUri == null) {
+      logger.warn("Received unknown URI: $uri")
+      return CompletableFuture.completedFuture(null)
+    }
+    val build = CompletableFuture.supplyAsync { build(effectiveUri, vfile, fileContents) }
+    runningBuild[effectiveUri.toString()] = build
     return build
   }
 
-  fun lastSuccessfulBuild(uri: String): PklModule? = buildCache[URI.create(uri)]
+  fun lastSuccessfulBuild(uri: String): PklModule? {
+    val effectiveUri = URI(uri).effectiveUri ?: return null
+    return buildCache[effectiveUri]
+  }
+
+  fun pathToModule(path: Path, virtualFile: VirtualFile): PklModule? {
+    if (!Files.exists(path) || path.isDirectory()) return null
+    val change = path.readText()
+    return fileToModule(change, path.normalize().toUri(), virtualFile)
+  }
+
+  fun fileToModule(contents: String, uri: URI, virtualFile: VirtualFile): PklModule? {
+    try {
+      val moduleCtx = parser.parseModule(contents)
+      return PklModuleImpl(moduleCtx, virtualFile).also { buildCache[uri] = it }
+    } catch (_: IOException) {
+      return null
+    }
+  }
+
+  fun findModuleInCache(uri: URI): PklModule? = buildCache[uri]
 
   private fun build(file: URI, vfile: VirtualFile, fileContents: String?): PklModule? {
     return try {
       val contents = fileContents ?: vfile.contents()
       logger.log("building $file")
       val moduleCtx = parser.parseModule(contents)
-      val module = PklModuleImpl(moduleCtx, file, vfile)
+      val module = PklModuleImpl(moduleCtx, vfile)
       val diagnostics = analyze(module)
       makeDiagnostics(file, diagnostics.map { it.toMessage() })
       buildCache[file] = module
@@ -118,32 +181,10 @@ class Builder(private val server: PklLSPServer, project: Project) : Component(pr
       return null
     }
 
-    fun pathToModule(path: Path, virtualFile: VirtualFile): PklModule? {
-      if (!Files.exists(path) || path.isDirectory()) return null
-      val change = path.readText()
-      return fileToModule(change, path.normalize().toUri(), virtualFile)
-    }
-
-    fun fileToModule(contents: String, uri: URI, virtualFile: VirtualFile): PklModule? {
-      val parser = Parser()
-      try {
-        val moduleCtx = parser.parseModule(contents)
-        return PklModuleImpl(moduleCtx, uri, virtualFile).also { buildCache[uri] = it }
-      } catch (_: IOException) {
-        return null
-      }
-    }
-
     private fun toParserError(ex: LexParseException): ParseError {
       val span = Span(ex.line, ex.column, ex.line, ex.column + ex.length)
       return ParseError(ex.message ?: "Parser error", span)
     }
-
-    private val buildCache: MutableMap<URI, PklModule> = ConcurrentHashMap()
-
-    val diagnosticsCache: MutableMap<URI, List<PklDiagnostic>> = ConcurrentHashMap()
-
-    fun findModuleInCache(uri: URI): PklModule? = buildCache[uri]
   }
 }
 

--- a/src/main/kotlin/org/pkl/lsp/Builder.kt
+++ b/src/main/kotlin/org/pkl/lsp/Builder.kt
@@ -177,10 +177,6 @@ class Builder(private val server: PklLSPServer, project: Project) : Component(pr
   }
 
   companion object {
-    private fun noop(): PklModule? {
-      return null
-    }
-
     private fun toParserError(ex: LexParseException): ParseError {
       val span = Span(ex.line, ex.column, ex.line, ex.column + ex.length)
       return ParseError(ex.message ?: "Parser error", span)

--- a/src/main/kotlin/org/pkl/lsp/Component.kt
+++ b/src/main/kotlin/org/pkl/lsp/Component.kt
@@ -15,11 +15,15 @@
  */
 package org.pkl.lsp
 
+import java.util.concurrent.CompletableFuture
+
 abstract class Component(protected val project: Project) {
   protected val logger by lazy { project.getLogger(this::class) }
 
   /** Gets called after the server is ready to accept messages. */
-  open fun initialize() {}
+  open fun initialize(): CompletableFuture<*> {
+    return CompletableFuture.completedFuture(Unit)
+  }
 
   /** Gets called when the server is shutting down. */
   open fun dispose() {}

--- a/src/main/kotlin/org/pkl/lsp/Component.kt
+++ b/src/main/kotlin/org/pkl/lsp/Component.kt
@@ -17,4 +17,10 @@ package org.pkl.lsp
 
 abstract class Component(protected val project: Project) {
   protected val logger by lazy { project.getLogger(this::class) }
+
+  /** Gets called after the server is ready to accept messages. */
+  open fun initialize() {}
+
+  /** Gets called when the server is shutting down. */
+  open fun dispose() {}
 }

--- a/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
@@ -110,20 +110,30 @@ class PklBaseModule(project: Project) {
   val comparableType: Type = aliasType("Comparable")
 
   val iterableType: Type by lazy {
-    Type.union(collectionType, mapType, dynamicType, listingType, mappingType, intSeqType, this)
+    Type.union(
+      collectionType,
+      mapType,
+      dynamicType,
+      listingType,
+      mappingType,
+      intSeqType,
+      this,
+      null,
+    )
   }
 
   fun spreadType(enclosingObjectClassType: Type.Class): Type {
     return when {
       enclosingObjectClassType.classEquals(listingType) -> {
         val elemType = enclosingObjectClassType.typeArguments[0]
-        if (elemType.isSubtypeOf(intType, this))
+        if (elemType.isSubtypeOf(intType, this, null))
           Type.union(
             collectionType.withTypeArguments(elemType),
             listingType.withTypeArguments(elemType),
             dynamicType,
             intSeqType,
             this,
+            null,
           )
         else
           Type.union(
@@ -131,6 +141,7 @@ class PklBaseModule(project: Project) {
             listingType.withTypeArguments(elemType),
             dynamicType,
             this,
+            null,
           )
       }
       enclosingObjectClassType.classEquals(mappingType) -> {
@@ -141,6 +152,7 @@ class PklBaseModule(project: Project) {
           mappingType.withTypeArguments(keyType, elemType),
           dynamicType,
           this,
+          null,
         )
       }
       enclosingObjectClassType.classEquals(dynamicType) -> iterableType
@@ -150,24 +162,44 @@ class PklBaseModule(project: Project) {
   }
 
   val additiveOperandType: Type by lazy {
-    Type.union(stringType, numberType, durationType, dataSizeType, collectionType, mapType, this)
+    Type.union(
+      stringType,
+      numberType,
+      durationType,
+      dataSizeType,
+      collectionType,
+      mapType,
+      this,
+      null,
+    )
   }
 
   val multiplicativeOperandType: Type by lazy {
-    Type.union(numberType, durationType, dataSizeType, this)
+    Type.union(numberType, durationType, dataSizeType, this, null)
   }
 
   val subscriptableType: Type by lazy {
-    Type.union(stringType, collectionType, mapType, listingType, mappingType, dynamicType, this)
+    Type.union(
+      stringType,
+      collectionType,
+      mapType,
+      listingType,
+      mappingType,
+      dynamicType,
+      this,
+      null,
+    )
   }
 
-  private val intPsiCache by lazy { intType.ctx.cache }
+  private val intPsiCache by lazy { intType.ctx.cache(null) }
 
-  private val floatPsiCache by lazy { floatType.ctx.cache }
+  private val floatPsiCache by lazy { floatType.ctx.cache(null) }
 
-  val booleanXorMethod: PklClassMethod by lazy { booleanType.ctx.cache.methods.getValue("xor") }
+  val booleanXorMethod: PklClassMethod by lazy {
+    booleanType.ctx.cache(null).methods.getValue("xor")
+  }
   val booleanImpliesMethod: PklClassMethod by lazy {
-    booleanType.ctx.cache.methods.getValue("implies")
+    booleanType.ctx.cache(null).methods.getValue("implies")
   }
 
   val intIsPositiveProperty: PklClassProperty by lazy {
@@ -232,92 +264,102 @@ class PklBaseModule(project: Project) {
   val floatIsBetweenMethod: PklClassMethod by lazy { floatPsiCache.methods.getValue("isBetween") }
 
   val durationIsBetweenMethod: PklClassMethod by lazy {
-    durationType.ctx.cache.methods.getValue("isBetween")
+    durationType.ctx.cache(null).methods.getValue("isBetween")
   }
   val durationIsPositiveProperty: PklClassProperty by lazy {
-    durationType.ctx.cache.properties.getValue("isPositive")
+    durationType.ctx.cache(null).properties.getValue("isPositive")
   }
 
   val dataSizeIsPositiveProperty: PklClassProperty by lazy {
-    dataSizeType.ctx.cache.properties.getValue("isPositive")
+    dataSizeType.ctx.cache(null).properties.getValue("isPositive")
   }
   val dataSizeIsBinaryUnitProperty: PklClassProperty by lazy {
-    dataSizeType.ctx.cache.properties.getValue("isBinaryUnit")
+    dataSizeType.ctx.cache(null).properties.getValue("isBinaryUnit")
   }
   val dataSizeIsDecimalUnitProperty: PklClassProperty by lazy {
-    dataSizeType.ctx.cache.properties.getValue("isDecimalUnit")
+    dataSizeType.ctx.cache(null).properties.getValue("isDecimalUnit")
   }
   val dataSizeIsBetweenMethod: PklClassMethod by lazy {
-    dataSizeType.ctx.cache.methods.getValue("isBetween")
+    dataSizeType.ctx.cache(null).methods.getValue("isBetween")
   }
 
   val stringIsEmptyProperty: PklClassProperty by lazy {
-    stringType.ctx.cache.properties.getValue("isEmpty")
+    stringType.ctx.cache(null).properties.getValue("isEmpty")
   }
   val stringIsRegexProperty: PklClassProperty by lazy {
-    stringType.ctx.cache.properties.getValue("isRegex")
+    stringType.ctx.cache(null).properties.getValue("isRegex")
   }
   val stringLengthProperty: PklClassProperty by lazy {
-    stringType.ctx.cache.properties.getValue("length")
+    stringType.ctx.cache(null).properties.getValue("length")
   }
   val stringMatchesMethod: PklClassMethod by lazy {
-    stringType.ctx.cache.methods.getValue("matches")
+    stringType.ctx.cache(null).methods.getValue("matches")
   }
   val stringContainsMethod: PklClassMethod by lazy {
-    stringType.ctx.cache.methods.getValue("contains")
+    stringType.ctx.cache(null).methods.getValue("contains")
   }
   val stringStartsWithMethod: PklClassMethod by lazy {
-    stringType.ctx.cache.methods.getValue("startsWith")
+    stringType.ctx.cache(null).methods.getValue("startsWith")
   }
   val stringEndsWithMethod: PklClassMethod by lazy {
-    stringType.ctx.cache.methods.getValue("endsWith")
+    stringType.ctx.cache(null).methods.getValue("endsWith")
   }
 
   val listIsDistinctProperty: PklClassProperty? by lazy {
-    listType.ctx.cache.properties["isDistinct"]
+    listType.ctx.cache(null).properties["isDistinct"]
   }
-  val listIsDistinctByMethod: PklClassMethod? by lazy { listType.ctx.cache.methods["isDistinctBy"] }
+  val listIsDistinctByMethod: PklClassMethod? by lazy {
+    listType.ctx.cache(null).methods["isDistinctBy"]
+  }
   val listIsEmptyProperty: PklClassProperty by lazy {
-    listType.ctx.cache.properties.getValue("isEmpty")
+    listType.ctx.cache(null).properties.getValue("isEmpty")
   }
-  val listFoldMethod: PklClassMethod? by lazy { listType.ctx.cache.methods["fold"] }
-  val listFoldIndexedMethod: PklClassMethod? by lazy { listType.ctx.cache.methods["foldIndexed"] }
-  val listJoinMethod: PklClassMethod by lazy { listType.ctx.cache.methods.getValue("join") }
+  val listFoldMethod: PklClassMethod? by lazy { listType.ctx.cache(null).methods["fold"] }
+  val listFoldIndexedMethod: PklClassMethod? by lazy {
+    listType.ctx.cache(null).methods["foldIndexed"]
+  }
+  val listJoinMethod: PklClassMethod by lazy { listType.ctx.cache(null).methods.getValue("join") }
   val listLengthProperty: PklClassProperty by lazy {
-    listType.ctx.cache.properties.getValue("length")
+    listType.ctx.cache(null).properties.getValue("length")
   }
 
   val listingDefaultProperty: PklClassProperty by lazy {
-    listingType.ctx.cache.properties.getValue("default")
+    listingType.ctx.cache(null).properties.getValue("default")
   }
   val listingToListMethod: PklClassMethod by lazy {
-    listingType.ctx.cache.methods.getValue("toList")
+    listingType.ctx.cache(null).methods.getValue("toList")
   }
 
   val setIsEmptyProperty: PklClassProperty by lazy {
-    setType.ctx.cache.properties.getValue("isEmpty")
+    setType.ctx.cache(null).properties.getValue("isEmpty")
   }
   val setLengthProperty: PklClassProperty by lazy {
-    setType.ctx.cache.properties.getValue("length")
+    setType.ctx.cache(null).properties.getValue("length")
   }
 
   val mapContainsKeyMethod: PklClassMethod by lazy {
-    mapType.ctx.cache.methods.getValue("containsKey")
+    mapType.ctx.cache(null).methods.getValue("containsKey")
   }
-  val mapFoldMethod: PklClassMethod? by lazy { mapType.ctx.cache.methods["fold"] }
-  val mapGetOrNullMethod: PklClassMethod by lazy { mapType.ctx.cache.methods.getValue("getOrNull") }
+  val mapFoldMethod: PklClassMethod? by lazy { mapType.ctx.cache(null).methods["fold"] }
+  val mapGetOrNullMethod: PklClassMethod by lazy {
+    mapType.ctx.cache(null).methods.getValue("getOrNull")
+  }
   val mapIsEmptyProperty: PklClassProperty by lazy {
-    mapType.ctx.cache.properties.getValue("isEmpty")
+    mapType.ctx.cache(null).properties.getValue("isEmpty")
   }
-  val mapKeysProperty: PklClassProperty by lazy { mapType.ctx.cache.properties.getValue("keys") }
+  val mapKeysProperty: PklClassProperty by lazy {
+    mapType.ctx.cache(null).properties.getValue("keys")
+  }
   val mapLengthProperty: PklClassProperty by lazy {
-    mapType.ctx.cache.properties.getValue("length")
+    mapType.ctx.cache(null).properties.getValue("length")
   }
 
   val mappingDefaultProperty: PklClassProperty by lazy {
-    mappingType.ctx.cache.properties.getValue("default")
+    mappingType.ctx.cache(null).properties.getValue("default")
   }
-  val mappingToMapMethod: PklClassMethod by lazy { mappingType.ctx.cache.methods.getValue("toMap") }
+  val mappingToMapMethod: PklClassMethod by lazy {
+    mappingType.ctx.cache(null).methods.getValue("toMap")
+  }
 
   private fun method(name: String): PklClassMethod =
     methods[name]

--- a/src/main/kotlin/org/pkl/lsp/PklLSP.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklLSP.kt
@@ -15,12 +15,13 @@
  */
 package org.pkl.lsp
 
+import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
 
 object PklLSP {
   fun run(verbose: Boolean) {
     val server = PklLSPServer(verbose)
-    val launcher = LSPLauncher.createServerLauncher(server, System.`in`, System.out)
+    val launcher = createLauncher(server)
 
     val client = launcher.remoteProxy
     server.connect(client)
@@ -28,4 +29,13 @@ object PklLSP {
     val future = launcher.startListening()
     future.get()
   }
+
+  private fun createLauncher(server: PklLSPServer): Launcher<PklLanguageClient> =
+    with(LSPLauncher.Builder<PklLanguageClient>()) {
+      setLocalService(server)
+      setRemoteInterface(PklLanguageClient::class.java)
+      setInput(System.`in`)
+      setOutput(System.out)
+      create()
+    }
 }

--- a/src/main/kotlin/org/pkl/lsp/PklLanguageClient.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklLanguageClient.kt
@@ -13,12 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pkl.lsp.services
+package org.pkl.lsp
 
-import java.net.URI
-import org.pkl.lsp.Component
-import org.pkl.lsp.Project
+import org.eclipse.lsp4j.jsonrpc.services.JsonNotification
+import org.eclipse.lsp4j.services.LanguageClient
+import org.pkl.lsp.messages.ActionableNotification
 
-class WorkspaceState(project: Project) : Component(project) {
-  val openFiles: MutableSet<URI> = mutableSetOf()
+interface PklLanguageClient : LanguageClient {
+  @JsonNotification("pkl/actionableNotification")
+  fun sendActionableNotification(params: ActionableNotification)
 }

--- a/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
@@ -49,7 +49,7 @@ class PklTextDocumentService(private val server: PklLSPServer, project: Project)
     val uri = URI(params.textDocument.uri)
     project.messageBus.emit(textDocumentTopic, TextDocumentEvent(uri, TextDocumentEventType.OPENED))
     val vfile = project.virtualFileManager.get(uri) ?: return
-    server.builder().requestBuild(uri, vfile, params.textDocument.text)
+    server.builder().requestBuild(vfile, params.textDocument.text)
   }
 
   override fun didChange(params: DidChangeTextDocumentParams) {
@@ -59,7 +59,7 @@ class PklTextDocumentService(private val server: PklLSPServer, project: Project)
       TextDocumentEvent(uri, TextDocumentEventType.CHANGED),
     )
     val vfile = project.virtualFileManager.get(uri) ?: return
-    server.builder().requestBuild(uri, vfile, params.contentChanges[0].text)
+    server.builder().requestBuild(vfile, params.contentChanges[0].text)
   }
 
   override fun didClose(params: DidCloseTextDocumentParams) {
@@ -76,7 +76,7 @@ class PklTextDocumentService(private val server: PklLSPServer, project: Project)
     project.messageBus.emit(textDocumentTopic, TextDocumentEvent(uri, TextDocumentEventType.SAVED))
     // guaranteed to exist because `file:` URIs are always supported.
     val file = project.virtualFileManager.get(uri)!!
-    server.builder().requestBuild(uri, file)
+    server.builder().requestBuild(file)
   }
 
   override fun hover(params: HoverParams): CompletableFuture<Hover> {

--- a/src/main/kotlin/org/pkl/lsp/PklWorkspaceService.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklWorkspaceService.kt
@@ -15,14 +15,40 @@
  */
 package org.pkl.lsp
 
-import org.eclipse.lsp4j.DidChangeConfigurationParams
-import org.eclipse.lsp4j.DidChangeWatchedFilesParams
+import java.net.URI
+import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.services.WorkspaceService
+import org.pkl.lsp.services.Topic
+
+val workspaceTopic = Topic<WorkspaceEvent>("WorkspaceEvent")
+
+data class WorkspaceEvent(val files: List<URI>, val type: WorkspaceEventType)
+
+enum class WorkspaceEventType {
+  CREATED,
+  DELETED,
+}
+
+val workspaceFolderTopic = Topic<WorkspaceFoldersChangeEvent>("WorkspaceFolderEvent")
 
 class PklWorkspaceService(private val project: Project) : WorkspaceService {
   override fun didChangeConfiguration(params: DidChangeConfigurationParams) {
     project.settingsManager.loadSettings()
   }
 
+  override fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) {
+    project.messageBus.emit(workspaceFolderTopic, params.event)
+  }
+
   override fun didChangeWatchedFiles(params: DidChangeWatchedFilesParams?) {}
+
+  override fun didCreateFiles(params: CreateFilesParams) {
+    val files = params.files.map { URI(it.uri) }
+    project.messageBus.emit(workspaceTopic, WorkspaceEvent(files, WorkspaceEventType.CREATED))
+  }
+
+  override fun didDeleteFiles(params: DeleteFilesParams) {
+    val files = params.files.map { URI(it.uri) }
+    project.messageBus.emit(workspaceTopic, WorkspaceEvent(files, WorkspaceEventType.DELETED))
+  }
 }

--- a/src/main/kotlin/org/pkl/lsp/PklWorkspaceService.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklWorkspaceService.kt
@@ -29,11 +29,16 @@ enum class WorkspaceEventType {
   DELETED,
 }
 
+val workspaceConfigurationChangedTopic =
+  Topic<WorkspaceConfigurationChangedEvent>("WorkspaceConfigurationChanged")
+
+object WorkspaceConfigurationChangedEvent
+
 val workspaceFolderTopic = Topic<WorkspaceFoldersChangeEvent>("WorkspaceFolderEvent")
 
 class PklWorkspaceService(private val project: Project) : WorkspaceService {
   override fun didChangeConfiguration(params: DidChangeConfigurationParams) {
-    project.settingsManager.loadSettings()
+    project.messageBus.emit(workspaceConfigurationChangedTopic, WorkspaceConfigurationChangedEvent)
   }
 
   override fun didChangeWorkspaceFolders(params: DidChangeWorkspaceFoldersParams) {

--- a/src/main/kotlin/org/pkl/lsp/Project.kt
+++ b/src/main/kotlin/org/pkl/lsp/Project.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.lsp
 
+import java.util.concurrent.CompletableFuture
 import kotlin.reflect.KClass
 import kotlin.reflect.KProperty
 import kotlin.reflect.full.isSubtypeOf
@@ -48,8 +49,8 @@ class Project(private val server: PklLSPServer) {
 
   val languageClient: PklLanguageClient by lazy { server.client() }
 
-  fun initialize() {
-    myComponents.forEach { it.initialize() }
+  fun initialize(): CompletableFuture<*> {
+    return CompletableFuture.allOf(*myComponents.map { it.initialize() }.toTypedArray())
   }
 
   fun dispose() {
@@ -67,8 +68,6 @@ class Project(private val server: PklLSPServer) {
   private val myComponents: Iterable<Component>
     get() {
       return this::class
-        .java
-        .kotlin
         .members
         .filterIsInstance(KProperty::class.java)
         .filter { it.returnType.isSubtypeOf(Component::class.starProjectedType) }

--- a/src/main/kotlin/org/pkl/lsp/Stdlib.kt
+++ b/src/main/kotlin/org/pkl/lsp/Stdlib.kt
@@ -22,7 +22,7 @@ import org.pkl.core.util.IoUtils
 import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklModuleImpl
 
-class Stdlib(private val project: Project) {
+class Stdlib(project: Project) : Component(project) {
   fun baseModule(): PklModule = stdlibModules["base"]!!
 
   fun getModule(name: String): PklModule? = stdlibModules[name]
@@ -39,7 +39,8 @@ class Stdlib(private val project: Project) {
   private fun loadStdlibModule(name: String, parser: Parser) {
     val text = loadStdlibSource(name)
     val moduleCtx = parser.parseModule(text)
-    val module = PklModuleImpl(moduleCtx, URI("pkl:$name"), StdlibFile(name, project))
+    val uri = URI("pkl:$name")
+    val module = PklModuleImpl(moduleCtx, project.virtualFileManager.get(uri)!!)
     stdlibModules[name] = module
   }
 
@@ -56,6 +57,7 @@ class Stdlib(private val project: Project) {
       "Benchmark",
       "DocPackageInfo",
       "DocsiteInfo",
+      "EvaluatorSettings",
       "json",
       "jsonnet",
       "math",

--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -184,10 +184,8 @@ class HttpsFile(override val uri: URI, override val project: Project) : BaseFile
   }
 }
 
-class JarFile : BaseFile {
-  override val path: Path
-  override val uri: URI
-  override val project: Project
+class JarFile(override val path: Path, override val uri: URI, override val project: Project) :
+  BaseFile() {
   override val name: String
     get() = path.name
 
@@ -209,18 +207,6 @@ class JarFile : BaseFile {
 
   override val pklAuthority: String
     get() = Origin.JAR.name.lowercase()
-
-  constructor(path: Path, uri: URI, project: Project) {
-    this.path = path
-    this.uri = uri
-    this.project = project
-  }
-
-  constructor(uri: URI, project: Project) {
-    this.uri = uri
-    this.path = Path.of(uri)
-    this.project = project
-  }
 
   override fun parent(): VirtualFile? = path.parent?.let { project.virtualFileManager.get(it) }
 

--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -16,16 +16,23 @@
 package org.pkl.lsp
 
 import java.net.URI
-import java.nio.file.FileSystemAlreadyExistsException
-import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.HashMap
+import java.util.concurrent.atomic.AtomicLong
+import javax.naming.OperationNotSupportedException
 import kotlin.io.path.name
+import kotlin.io.path.nameWithoutExtension
 import kotlin.io.path.readText
+import org.pkl.core.parser.Parser
 import org.pkl.core.util.IoUtils
 import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklModuleImpl
+import org.pkl.lsp.packages.PackageDependency
+import org.pkl.lsp.packages.dto.PackageMetadata
+import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.services.PklProjectManager.Companion.PKL_PROJECT_FILENAME
 import org.pkl.lsp.util.CachedValue
+import org.pkl.lsp.util.ModificationTracker
 
 enum class Origin {
   FILE,
@@ -46,11 +53,27 @@ enum class Origin {
   }
 }
 
-interface VirtualFile {
+interface VirtualFile : ModificationTracker {
   val name: String
   val uri: URI
   val pklAuthority: String
   val project: Project
+
+  /**
+   * The NIO path backing this file.
+   *
+   * May throw [OperationNotSupportedException] if this file cannot be converted to a [Path].
+   */
+  val path: Path
+
+  /** The closest ancestor directory containing a PklProject file. */
+  val pklProjectDir: VirtualFile?
+
+  /** Tells if this file is in a directory that contains a PklProject file. */
+  val pklProject: PklProject?
+
+  /** Tells if this file is within a package. */
+  val `package`: PackageDependency?
 
   fun parent(): VirtualFile?
 
@@ -59,59 +82,66 @@ interface VirtualFile {
   fun toModule(): PklModule?
 
   fun contents(): String
-
-  companion object {
-    fun fromUri(uri: URI, project: Project): VirtualFile? {
-      val logger = project.getLogger(this::class)
-      return if (uri.scheme.equals("file", ignoreCase = true)) {
-        FsFile(Path.of(uri), project)
-      } else if (uri.scheme.equals("pkl", ignoreCase = true)) {
-        val origin = Origin.fromString(uri.authority.uppercase())
-        if (origin == null) {
-          logger.error("Invalid origin for pkl url: ${uri.authority}")
-          return null
-        }
-        val path = uri.path.drop(1)
-        when (origin) {
-          Origin.FILE -> FsFile(Path.of(path), project)
-          Origin.STDLIB -> StdlibFile(path.replace(".pkl", ""), project)
-          Origin.HTTPS -> HttpsFile(URI.create(path), project)
-          Origin.JAR -> JarFile(URI(path), project)
-          else -> {
-            logger.error("Origin $origin is not supported")
-            null
-          }
-        }
-      } else null
-    }
-  }
 }
 
-class FsFile(val path: Path, override val project: Project) : VirtualFile {
+sealed class BaseFile : VirtualFile {
+  internal val modificationCount: AtomicLong = AtomicLong(0)
+
+  override fun getModificationCount(): Long = modificationCount.get()
+}
+
+class FsFile(override val path: Path, override val project: Project) : BaseFile() {
   override val name: String = path.name
   override val uri: URI = path.toUri()
   override val pklAuthority: String = Origin.FILE.name.lowercase()
 
-  override fun parent(): VirtualFile? = path.parent?.let { FsFile(it, project) }
+  override val pklProjectDir: VirtualFile?
+    get() =
+      project.cachedValuesManager.getCachedValue("FsFile.getProjectDir($path)") {
+        val dependency = project.pklProjectManager.addedOrRemovedFilesModificationTracker
+        var dir = if (Files.isDirectory(path)) this else parent()
+        while (dir != null) {
+          if (dir.resolve(PKL_PROJECT_FILENAME) != null) {
+            return@getCachedValue CachedValue(dir, listOf(dependency))
+          }
+          dir = dir.parent()
+        }
+        CachedValue(null, listOf(dependency))
+      }
+
+  override val pklProject: PklProject?
+    get() = pklProjectDir?.let { project.pklProjectManager.getPklProject(it) }
+
+  override val `package`: PackageDependency? = null
+
+  override fun parent(): VirtualFile? = path.parent?.let { project.virtualFileManager.get(it) }
 
   override fun resolve(path: String): VirtualFile? {
     val resolvedPath = this.path.resolve(path)
-    return if (Files.exists(resolvedPath)) FsFile(this.path.resolve(path), project) else null
+    return if (Files.exists(resolvedPath)) project.virtualFileManager.get(resolvedPath.toUri())
+    else null
   }
 
   override fun toModule(): PklModule? {
     // get this module from the cache if possible so changes to it are propagated even
     // if the file was not saved
-    return Builder.findModuleInCache(uri) ?: Builder.pathToModule(path, this)
+    val builder = project.builder
+    return builder.findModuleInCache(uri) ?: builder.pathToModule(path, this)
   }
 
   override fun contents(): String = path.readText()
 }
 
-class StdlibFile(moduleName: String, override val project: Project) : VirtualFile {
+class StdlibFile(moduleName: String, override val project: Project) : BaseFile() {
   override val name: String = moduleName
   override val uri: URI = URI("pkl:$moduleName")
   override val pklAuthority: String = Origin.STDLIB.name.lowercase()
+  override val path: Path
+    get() = throw OperationNotSupportedException()
+
+  override val pklProject: PklProject? = null
+  override val pklProjectDir: VirtualFile? = null
+  override val `package`: PackageDependency? = null
 
   override fun parent(): VirtualFile? = null
 
@@ -126,17 +156,23 @@ class StdlibFile(moduleName: String, override val project: Project) : VirtualFil
   }
 }
 
-class HttpsFile(override val uri: URI, override val project: Project) : VirtualFile {
+class HttpsFile(override val uri: URI, override val project: Project) : BaseFile() {
   override val name: String = ""
   override val pklAuthority: String = Origin.HTTPS.name.lowercase()
+  override val path: Path
+    get() = throw OperationNotSupportedException()
 
-  override fun parent(): VirtualFile {
+  override val pklProject: PklProject? = null
+  override val pklProjectDir: VirtualFile? = null
+  override val `package`: PackageDependency? = null
+
+  override fun parent(): VirtualFile? {
     val newUri = if (uri.path.endsWith("/")) uri.resolve("..") else uri.resolve(".")
-    return HttpsFile(newUri, project)
+    return project.virtualFileManager.get(newUri)
   }
 
-  override fun resolve(path: String): VirtualFile {
-    return HttpsFile(uri.resolve(path), project)
+  override fun resolve(path: String): VirtualFile? {
+    return project.virtualFileManager.get(uri.resolve(path))
   }
 
   override fun toModule(): PklModule? {
@@ -148,20 +184,28 @@ class HttpsFile(override val uri: URI, override val project: Project) : VirtualF
   }
 }
 
-private fun ensureJarFileSystem(uri: URI) {
-  try {
-    FileSystems.newFileSystem(uri, HashMap<String, Any>())
-  } catch (e: FileSystemAlreadyExistsException) {
-    FileSystems.getFileSystem(uri)
-  }
-}
-
-class JarFile : VirtualFile {
-  val path: Path
+class JarFile : BaseFile {
+  override val path: Path
   override val uri: URI
   override val project: Project
   override val name: String
     get() = path.name
+
+  override val pklProject: PklProject? = null
+  override val pklProjectDir: VirtualFile? = null
+
+  override val `package`: PackageDependency?
+    get() =
+      project.cachedValuesManager.getCachedValue("JarFile.package(${uri})") {
+        val jarFile: Path = Path.of(URI(uri.toString().drop(4).substringBefore("!/")))
+        val jsonFile =
+          jarFile.parent.resolve(jarFile.nameWithoutExtension + ".json")
+            ?: return@getCachedValue null
+        if (!Files.exists(jsonFile)) return@getCachedValue null
+        val metadata = PackageMetadata.load(jsonFile)
+        val packageUri = metadata.packageUri
+        CachedValue(packageUri.asPackageDependency(null))
+      }
 
   override val pklAuthority: String
     get() = Origin.JAR.name.lowercase()
@@ -173,26 +217,50 @@ class JarFile : VirtualFile {
   }
 
   constructor(uri: URI, project: Project) {
-    ensureJarFileSystem(uri)
     this.uri = uri
     this.path = Path.of(uri)
     this.project = project
   }
 
-  override fun parent(): VirtualFile? = path.parent?.let { JarFile(it, it.toUri(), project) }
+  override fun parent(): VirtualFile? = path.parent?.let { project.virtualFileManager.get(it) }
 
-  override fun resolve(path: String): VirtualFile? {
-    val resolvedPath = this.path.resolve(path)
-    return if (Files.exists(resolvedPath)) JarFile(this.path.resolve(path).toUri(), project)
-    else null
-  }
+  override fun resolve(path: String): VirtualFile? =
+    project.virtualFileManager.get(this.path.resolve(path))
 
   override fun toModule(): PklModule? {
-    return Builder.findModuleInCache(uri) ?: Builder.pathToModule(path, this)
+    val builder = project.builder
+    return builder.findModuleInCache(uri) ?: builder.pathToModule(path, this)
   }
 
   override fun contents(): String =
     project.cachedValuesManager.getCachedValue("${javaClass.simpleName}-contents-${uri}") {
       CachedValue(path.readText())
     }!!
+}
+
+class EphemeralFile(private val text: String, override val project: Project) : BaseFile() {
+  companion object {
+    private val parser = Parser()
+  }
+
+  override val name: String = "ephemeral"
+  override val uri: URI = URI("fake:fake")
+  override val pklAuthority: String = "fake"
+  override val path: Path
+    get() = throw OperationNotSupportedException()
+
+  override val pklProject: PklProject? = null
+  override val pklProjectDir: VirtualFile? = null
+  override val `package`: PackageDependency? = null
+
+  override fun parent(): VirtualFile? = null
+
+  override fun resolve(path: String): VirtualFile? = null
+
+  override fun toModule(): PklModule {
+    val ctx = parser.parseModule(text)
+    return PklModuleImpl(ctx, this)
+  }
+
+  override fun contents(): String = text
 }

--- a/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
@@ -18,16 +18,18 @@ package org.pkl.lsp
 import java.net.URI
 import java.nio.file.*
 import java.util.*
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ConcurrentHashMap
 
 class VirtualFileManager(project: Project) : Component(project) {
-  override fun initialize() {
+  override fun initialize(): CompletableFuture<*> {
     project.messageBus.subscribe(textDocumentTopic) { event ->
       val file = files[event.file] ?: return@subscribe
       if (event.type == TextDocumentEventType.CHANGED) {
         file.modificationCount.incrementAndGet()
       }
     }
+    return CompletableFuture.completedFuture(Unit)
   }
 
   private val files: MutableMap<URI, BaseFile> = ConcurrentHashMap()

--- a/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
@@ -1,0 +1,83 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import java.net.URI
+import java.nio.file.*
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+
+class VirtualFileManager(project: Project) : Component(project) {
+  override fun initialize() {
+    project.messageBus.subscribe(textDocumentTopic) { event ->
+      val file = files[event.file] ?: return@subscribe
+      if (event.type == TextDocumentEventType.CHANGED) {
+        file.modificationCount.incrementAndGet()
+      }
+    }
+  }
+
+  private val files: MutableMap<URI, BaseFile> = ConcurrentHashMap()
+
+  fun get(path: Path): VirtualFile? {
+    return if (!Files.exists(path)) null else get(path.toUri(), path)
+  }
+
+  fun get(uri: URI, path: Path? = null): VirtualFile? {
+    val effectiveUri = uri.effectiveUri ?: return null
+    val existing = files[effectiveUri]
+    if (existing != null) {
+      return existing
+    }
+    return create(effectiveUri, path)
+  }
+
+  fun getFsFile(path: Path): FsFile? = get(path) as? FsFile
+
+  fun getFsFile(uri: URI): FsFile? = get(uri) as? FsFile
+
+  /**
+   * Creates a one-off virtual file; this file does not get managed (workspace events do not cause
+   * this file modification count nor contents to change).
+   */
+  fun getEphemeral(text: String): VirtualFile = EphemeralFile(text, project)
+
+  private fun create(uri: URI, path: Path? = null): VirtualFile? {
+    val effectiveUri = uri.effectiveUri ?: return null
+    val file =
+      when (effectiveUri.scheme) {
+        "file" -> FsFile(path ?: Path.of(effectiveUri), this.project)
+        "jar" -> {
+          ensureJarFileSystem(effectiveUri)
+          JarFile(path ?: Path.of(effectiveUri), effectiveUri, project)
+        }
+        "pkl" -> StdlibFile(effectiveUri.schemeSpecificPart, project)
+        else -> throw Exception("Unsupported scheme: ${effectiveUri.scheme}")
+      }
+    return file.also { files[effectiveUri] = file }
+  }
+
+  // This is technically a memory leak, albeit a mild one and should be tolerable.
+  //
+  // For every new package opened, its file system is never closed and kept on heap.
+  private fun ensureJarFileSystem(uri: URI) {
+    try {
+      FileSystems.newFileSystem(uri, HashMap<String, Any>())
+    } catch (e: FileSystemAlreadyExistsException) {
+      FileSystems.getFileSystem(uri)
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/actions/PklDownloadPackageAction.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklDownloadPackageAction.kt
@@ -17,6 +17,7 @@ package org.pkl.lsp.actions
 
 import org.eclipse.lsp4j.CodeActionDisabled
 import org.eclipse.lsp4j.CodeActionKind
+import org.pkl.lsp.ErrorMessages
 import org.pkl.lsp.Project
 import org.pkl.lsp.packages.dto.PackageUri
 
@@ -30,9 +31,8 @@ class PklDownloadPackageAction(project: Project, packageUri: PackageUri) :
 
   override val arguments: List<Any> = listOf(packageUri.toString())
 
-  override val disabled: CodeActionDisabled?
-    get() =
-      if (project.settingsManager.settings.pklCliPath == null)
-        CodeActionDisabled("Pkl CLI is not configured")
-      else null
+  override val disabled: CodeActionDisabled? =
+    if (project.pklCli.isUnavailable)
+      CodeActionDisabled(ErrorMessages.create("pklCliNotConfigured"))
+    else null
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
@@ -25,10 +25,11 @@ import org.pkl.lsp.ast.PklProperty
 class ModuleMemberAnalyzer(project: Project) : Analyzer(project) {
 
   override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+    val context = node.containingFile.pklProject
     when (node) {
       is PklProperty -> {
         val isAmends = node.enclosingModule?.isAmend ?: false
-        val supermodule = node.enclosingModule?.supermodule?.cache
+        val supermodule = node.enclosingModule?.supermodule(context)?.cache(context)
 
         if (isAmends && !node.isLocal && supermodule != null) {
           val superProperty = supermodule.properties[node.name]

--- a/src/main/kotlin/org/pkl/lsp/ast/Member.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Member.kt
@@ -20,6 +20,7 @@ import org.pkl.lsp.LSPUtil.firstInstanceOf
 import org.pkl.lsp.PklVisitor
 import org.pkl.lsp.Project
 import org.pkl.lsp.VirtualFile
+import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitors
 import org.pkl.lsp.resolvers.Resolvers
 import org.pkl.lsp.type.computeThisType
@@ -59,15 +60,15 @@ class PklClassPropertyImpl(
     return visitor.visitClassProperty(this)
   }
 
-  override fun resolve(): PklNode? {
+  override fun resolve(context: PklProject?): PklNode? {
     val base = project.pklBaseModule
     val visitor = ResolveVisitors.firstElementNamed(name, base)
     return when {
       type != null -> this
       isLocal -> this
       else -> {
-        val receiverType = computeThisType(base, mapOf())
-        Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor)
+        val receiverType = computeThisType(base, mapOf(), context)
+        Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor, context)
       }
     }
   }
@@ -237,15 +238,15 @@ class PklObjectPropertyImpl(
     return visitor.visitObjectProperty(this)
   }
 
-  override fun resolve(): PklNode? {
+  override fun resolve(context: PklProject?): PklNode? {
     val base = project.pklBaseModule
     val visitor = ResolveVisitors.firstElementNamed(name, base)
     return when {
       type != null -> this
       isLocal -> this
       else -> {
-        val receiverType = computeThisType(base, mapOf())
-        Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor)
+        val receiverType = computeThisType(base, mapOf(), context)
+        Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor, context)
       }
     }
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNodeFactory.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNodeFactory.kt
@@ -15,26 +15,11 @@
  */
 package org.pkl.lsp.ast
 
-import java.net.URI
-import java.nio.file.Path
-import org.pkl.core.parser.Parser
-import org.pkl.lsp.FsFile
 import org.pkl.lsp.Project
 
 object PklNodeFactory {
-  @Suppress("MemberVisibilityCanBePrivate")
-  fun createModule(project: Project, text: String): PklModule {
-    return PklModuleImpl(
-      parser.parseModule(text),
-      URI("fake:module"),
-      FsFile(Path.of("."), project),
-    )
-  }
-
   fun createTypeParameter(project: Project, name: String): PklTypeParameter {
-    val module = createModule(project, "class X<$name>")
+    val module = project.virtualFileManager.getEphemeral("class X<$name>").toModule()!!
     return module.classes[0].classHeader.typeParameterList!!.typeParameters[0]
   }
-
-  private val parser: Parser = Parser()
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -20,6 +20,7 @@ import org.pkl.core.parser.antlr.PklParser.*
 import org.pkl.lsp.LSPUtil.firstInstanceOf
 import org.pkl.lsp.PklVisitor
 import org.pkl.lsp.Project
+import org.pkl.lsp.packages.dto.PklProject
 
 class PklTypeAnnotationImpl(
   project: Project,
@@ -210,7 +211,9 @@ class PklTypeAliasImpl(project: Project, override val parent: PklNode?, ctx: Typ
   override val modifiers: List<Terminal>? by lazy { typeAliasHeader.modifiers }
   override val name: String by lazy { ctx.typeAliasHeader().Identifier().text }
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
-  override val isRecursive: Boolean by lazy { isRecursive(mutableSetOf()) }
+
+  override fun isRecursive(context: PklProject?): Boolean = isRecursive(mutableSetOf(), context)
+
   override val typeParameterList: PklTypeParameterList? by lazy {
     typeAliasHeader.typeParameterList
   }

--- a/src/main/kotlin/org/pkl/lsp/features/CodeActionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/CodeActionFeature.kt
@@ -21,18 +21,16 @@ import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.jsonrpc.messages.Either
-import org.pkl.lsp.Builder
 import org.pkl.lsp.Component
 import org.pkl.lsp.LSPUtil.toRange
-import org.pkl.lsp.PklLSPServer
 import org.pkl.lsp.Project
 
-class CodeActionFeature(private val server: PklLSPServer, project: Project) : Component(project) {
+class CodeActionFeature(project: Project) : Component(project) {
 
   fun onCodeAction(params: CodeActionParams): CompletableFuture<List<Either<Command, CodeAction>>> {
-    return server.builder().runningBuild(params.textDocument.uri).thenApply {
+    return project.builder.runningBuild(params.textDocument.uri).thenApply {
       val diagnostics =
-        Builder.diagnosticsCache[URI(params.textDocument.uri)]
+        project.builder.diagnosticsCache[URI(params.textDocument.uri)]
           ?: return@thenApply emptyList<Either<Command, CodeAction>>()
       diagnostics
         .filter { it.span.toRange() == params.range }

--- a/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
@@ -23,6 +23,7 @@ import org.pkl.lsp.Component
 import org.pkl.lsp.PklLSPServer
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*
+import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitors
 import org.pkl.lsp.resolvers.Resolvers
 import org.pkl.lsp.type.*
@@ -31,86 +32,93 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
   fun onHover(params: HoverParams): CompletableFuture<Hover> {
     fun run(mod: PklModule?): Hover {
       if (mod == null) return Hover(listOf())
+      val context = mod.containingFile.pklProject
       val line = params.position.line + 1
       val col = params.position.character + 1
       val hoverText =
-        mod.findBySpan(line, col)?.let { resolveHover(it, line, col) } ?: return Hover(listOf())
+        mod.findBySpan(line, col)?.let { resolveHover(it, line, col, context) }
+          ?: return Hover(listOf())
       return Hover(MarkupContent("markdown", hoverText))
     }
     return server.builder().runningBuild(params.textDocument.uri).thenApply(::run)
   }
 
-  private fun resolveHover(originalNode: PklNode, line: Int, col: Int): String? {
-    val node = originalNode.resolveReference(line, col) ?: return null
+  private fun resolveHover(
+    originalNode: PklNode,
+    line: Int,
+    col: Int,
+    context: PklProject?,
+  ): String? {
+    val node = originalNode.resolveReference(line, col, context) ?: return null
     val base = project.pklBaseModule
-    if (node !== originalNode) return node.toMarkdown(originalNode)
+    if (node !== originalNode) return node.toMarkdown(originalNode, context)
     return when (node) {
-      is PklProperty -> node.toMarkdown(originalNode)
-      is PklMethod -> node.toMarkdown(originalNode)
+      is PklProperty -> node.toMarkdown(originalNode, context)
+      is PklMethod -> node.toMarkdown(originalNode, context)
       is PklMethodHeader -> {
         val name = node.identifier
         // check if hovering over the method name
         if (name != null && name.span.matches(line, col)) {
-          node.parent?.toMarkdown(originalNode)
+          node.parent?.toMarkdown(originalNode, context)
         } else null
       }
-      is PklClass -> node.toMarkdown(originalNode)
+      is PklClass -> node.toMarkdown(originalNode, context)
       is PklClassHeader -> {
         val name = node.identifier
         // check if hovering over the class name
         if (name != null && name.span.matches(line, col)) {
           // renders the class, which contains the doc comment
-          node.parent?.toMarkdown(originalNode)
+          node.parent?.toMarkdown(originalNode, context)
         } else null
       }
       is PklQualifiedIdentifier ->
         when (val par = node.parent) {
           // render the module declaration
-          is PklModuleHeader -> par.parent?.toMarkdown(originalNode)
+          is PklModuleHeader -> par.parent?.toMarkdown(originalNode, context)
           else -> null
         }
-      is PklDeclaredType -> node.toMarkdown(originalNode)
-      is PklModule -> node.toMarkdown(originalNode)
+      is PklDeclaredType -> node.toMarkdown(originalNode, context)
+      is PklModule -> node.toMarkdown(originalNode, context)
       // render the typealias which contains the doc comments
-      is PklTypeAliasHeader -> node.parent?.toMarkdown(originalNode)
-      is PklTypedIdentifier -> node.toMarkdown(originalNode)
-      is PklThisExpr -> node.computeThisType(base, mapOf()).toMarkdown()
-      is PklModuleExpr -> node.enclosingModule?.toMarkdown(originalNode)
+      is PklTypeAliasHeader -> node.parent?.toMarkdown(originalNode, context)
+      is PklTypedIdentifier -> node.toMarkdown(originalNode, context)
+      is PklThisExpr -> node.computeThisType(base, mapOf(), context).toMarkdown(context)
+      is PklModuleExpr -> node.enclosingModule?.toMarkdown(originalNode, context)
       else -> null
     }
   }
 
-  private fun PklNode.render(originalNode: PklNode?): String =
+  private fun PklNode.render(originalNode: PklNode?, context: PklProject?): String =
     when (this) {
       is PklProperty ->
         buildString {
           append(modifiers.render())
           if (isLocal || isFixedOrConst) {
-            append(renderTypeAnnotation(name, type, this@render, originalNode))
+            append(renderTypeAnnotation(name, type, this@render, originalNode, context))
           } else {
             append(name)
             append(": ")
-            append(type?.render(originalNode) ?: "unknown")
+            append(type?.render(originalNode, context) ?: "unknown")
           }
         }
       is PklStringLiteralType -> "\"$text\""
       is PklMethod -> {
         val modifiers = modifiers.render()
-        modifiers + methodHeader.render(originalNode)
+        modifiers + methodHeader.render(originalNode, context)
       }
       is PklMethodHeader ->
         buildString {
           append("function ")
           append(identifier?.text ?: "<method>>")
-          append(typeParameterList?.render(originalNode) ?: "")
-          append(parameterList?.render(originalNode) ?: "()")
+          append(typeParameterList?.render(originalNode, context) ?: "")
+          append(parameterList?.render(originalNode, context) ?: "()")
           val returnTypeStr =
             if (returnType != null) {
-              returnType!!.render(originalNode)
+              returnType!!.render(originalNode, context)
             } else {
               val parent = this@render.parent
               if (parent != null && parent is PklMethod) {
-                val type = parent.body.computeExprType(project.pklBaseModule, mapOf())
+                val type = parent.body.computeExprType(project.pklBaseModule, mapOf(), context)
                 type.render()
               } else "unknown"
             }
@@ -118,21 +126,25 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
           append(returnTypeStr)
         }
       is PklParameterList -> {
-        elements.joinToString(", ", prefix = "(", postfix = ")") { it.render(originalNode) }
+        elements.joinToString(", ", prefix = "(", postfix = ")") {
+          it.render(originalNode, context)
+        }
       }
       is PklTypeParameterList -> {
-        typeParameters.joinToString(", ", prefix = "<", postfix = ">") { it.render(originalNode) }
+        typeParameters.joinToString(", ", prefix = "<", postfix = ">") {
+          it.render(originalNode, context)
+        }
       }
       is PklParameter ->
         if (isUnderscore) {
           "_"
         } else {
           // cannot be null here if it's not underscore
-          typedIdentifier!!.render(originalNode)
+          typedIdentifier!!.render(originalNode, context)
         }
-      is PklTypeAnnotation -> ": ${type!!.render(originalNode)}"
+      is PklTypeAnnotation -> ": ${type!!.render(originalNode, context)}"
       is PklTypedIdentifier ->
-        renderTypeAnnotation(identifier?.text, typeAnnotation?.type, this, originalNode)!!
+        renderTypeAnnotation(identifier?.text, typeAnnotation?.type, this, originalNode, context)!!
       is PklTypeParameter -> {
         val vari = variance?.name?.lowercase()?.let { "$it " } ?: ""
         "$vari$name"
@@ -142,19 +154,19 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
           append(modifiers.render())
           append("class ")
           append(classHeader.identifier?.text ?: "<class>")
-          typeParameterList?.let { append(it.render(originalNode)) }
+          typeParameterList?.let { append(it.render(originalNode, context)) }
           supertype?.let {
             append(" extends ")
-            append(it.render(originalNode))
+            append(it.render(originalNode, context))
           }
         }
-      is PklModule -> declaration?.render(originalNode) ?: "module $moduleName"
+      is PklModule -> declaration?.render(originalNode, context) ?: "module $moduleName"
       is PklModuleDeclaration ->
         buildString {
           append(modifiers.render())
           append("module ")
           // can never be null
-          append(moduleHeader!!.render(originalNode))
+          append(moduleHeader!!.render(originalNode, context))
         }
       is PklModuleHeader ->
         buildString {
@@ -173,17 +185,18 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
           }
           moduleUri?.stringConstant?.escapedText()?.let { append("\"$it\"") }
           val definitionType =
-            resolve().computeResolvedImportType(project.pklBaseModule, mapOf(), false)
+            resolve(context)
+              .computeResolvedImportType(project.pklBaseModule, mapOf(), false, context)
           append(": ")
           definitionType.render(this, DefaultTypeNameRenderer)
         }
-      is PklTypeAlias -> typeAliasHeader.render(originalNode)
+      is PklTypeAlias -> typeAliasHeader.render(originalNode, context)
       is PklTypeAliasHeader ->
         buildString {
           append(modifiers.render())
           append("typealias ")
           append(identifier?.text)
-          typeParameterList?.let { append(it.render(originalNode)) }
+          typeParameterList?.let { append(it.render(originalNode, context)) }
         }
       is PklType -> render()
       else -> text
@@ -199,6 +212,7 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     type: PklType?,
     node: PklNode,
     originalNode: PklNode?,
+    context: PklProject?,
   ): String? {
     if (name == null) return null
     return buildString {
@@ -216,11 +230,12 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
           val computedType =
             Resolvers.resolveUnqualifiedAccess(
               originalNode,
-              node.computeThisType(project.pklBaseModule, mapOf()),
+              node.computeThisType(project.pklBaseModule, mapOf(), context),
               true,
               project.pklBaseModule,
               mapOf(),
               visitor,
+              context,
             )
           append(": ")
           if (computedType is Type.Unknown && type != null) {
@@ -231,10 +246,10 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
         }
         type != null -> {
           append(": ")
-          append(type.render(originalNode))
+          append(type.render(originalNode, context))
         }
         else -> {
-          val computedType = node.computeResolvedImportType(project.pklBaseModule, mapOf())
+          val computedType = node.computeResolvedImportType(project.pklBaseModule, mapOf(), context)
           append(": ")
           computedType.render(this)
         }
@@ -242,9 +257,9 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     }
   }
 
-  private fun Type.toMarkdown(): String {
+  private fun Type.toMarkdown(context: PklProject?): String {
     val markdown = render()
-    val ctx = getNode(project)
+    val ctx = getNode(project, context)
     return when {
       ctx is PklModule && ctx.declaration != null ->
         showDocCommentAndModule(ctx.declaration!!, markdown)
@@ -252,8 +267,8 @@ class HoverFeature(val server: PklLSPServer, project: Project) : Component(proje
     }
   }
 
-  private fun PklNode.toMarkdown(originalNode: PklNode?): String {
-    val markdown = render(originalNode)
+  private fun PklNode.toMarkdown(originalNode: PklNode?, context: PklProject?): String {
+    val markdown = render(originalNode, context)
     return when {
       this is PklModule && declaration != null -> showDocCommentAndModule(declaration!!, markdown)
       else -> showDocCommentAndModule(this, markdown)

--- a/src/main/kotlin/org/pkl/lsp/messages/ActionableNotification.kt
+++ b/src/main/kotlin/org/pkl/lsp/messages/ActionableNotification.kt
@@ -13,20 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pkl.lsp.util
+package org.pkl.lsp.messages
 
-import java.util.concurrent.atomic.AtomicLong
+import org.eclipse.lsp4j.Command
+import org.eclipse.lsp4j.MessageType
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
 
-interface ModificationTracker {
-  fun getModificationCount(): Long
-}
-
-class SimpleModificationTracker : ModificationTracker {
-  private val count = AtomicLong(0)
-
-  override fun getModificationCount(): Long = count.get()
-
-  fun increment() {
-    count.incrementAndGet()
-  }
+data class ActionableNotification(
+  val type: MessageType,
+  val message: String,
+  val commands: List<Command>,
+) {
+  override fun toString(): String = MessageJsonHandler.toString(this)
 }

--- a/src/main/kotlin/org/pkl/lsp/packages/dto/PackageUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/packages/dto/PackageUri.kt
@@ -107,5 +107,6 @@ data class PackageUri(
   val relativeMetadataFiles =
     listOf(encodePath("package-2/$packageFilenameBase.json"), "package-1/$packageFilenameBase.json")
 
-  fun asPackageDependency(): PackageDependency = PackageDependency(this, this.checksums)
+  fun asPackageDependency(context: PklProject?): PackageDependency =
+    PackageDependency(this, context, this.checksums)
 }

--- a/src/main/kotlin/org/pkl/lsp/packages/dto/PklProject.kt
+++ b/src/main/kotlin/org/pkl/lsp/packages/dto/PklProject.kt
@@ -1,0 +1,107 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.packages.dto
+
+import java.net.URI
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import org.pkl.lsp.VirtualFile
+import org.pkl.lsp.packages.Dependency
+import org.pkl.lsp.packages.LocalProjectDependency
+import org.pkl.lsp.packages.PackageDependency
+import org.pkl.lsp.packages.toDependency
+import org.pkl.lsp.util.URISerializer
+
+data class PklProject(val metadata: DerivedProjectMetadata, val projectDeps: ProjectDeps?) {
+
+  companion object {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun parseMetadata(input: String): List<DerivedProjectMetadata> {
+      return json.decodeFromString(input)
+    }
+
+    private fun parseDeps(input: String): ProjectDeps {
+      return json.decodeFromString(input)
+    }
+
+    fun loadProjectDeps(file: VirtualFile): ProjectDeps {
+      val contents = file.contents()
+      return parseDeps(contents)
+    }
+
+    @Serializable
+    data class DerivedProjectMetadata(
+      @Serializable(with = URISerializer::class) val projectFileUri: URI,
+      val packageUri: PackageUri?,
+      val declaredDependencies: Map<String, PackageUri>,
+      val evaluatorSettings: EvaluatorSettings?,
+    )
+
+    @Serializable data class EvaluatorSettings(val moduleCacheDir: String? = null)
+
+    @Serializable
+    data class ProjectDeps(
+      val schemaVersion: Int,
+      val resolvedDependencies: Map<String, ResolvedDependency>,
+    ) {
+      /** Given a package URI, return the resolved dependency for it. */
+      fun getResolvedDependency(packageUri: PackageUri): ResolvedDependency? {
+        val packageUriStr = packageUri.toString()
+        return resolvedDependencies.entries.find { packageUriStr.startsWith(it.key) }?.value
+      }
+    }
+  }
+
+  val projectFile: Path by lazy { Path.of(metadata.projectFileUri) }
+
+  val projectDir: Path by lazy { projectFile.parent }
+
+  /** The dependencies declared within the PklProject file */
+  val myDependencies: Map<String, Dependency>
+    get() {
+      return metadata.declaredDependencies.entries.fold(mapOf()) { acc, (name, packageUri) ->
+        val dep = projectDeps?.getResolvedDependency(packageUri)?.asDependency ?: return@fold acc
+        acc.plus(name to dep)
+      }
+    }
+
+  fun getResolvedDependencies(context: PklProject?): Map<String, Dependency> {
+    if (context == null || context === this) return myDependencies
+    return myDependencies.mapValues { (_, dep) ->
+      // best-effort approach; if the dependency is not found in [context], show what's found in
+      // [myDependencies].
+      context.projectDeps?.getResolvedDependency(dep.packageUri)?.toDependency(context) ?: dep
+    }
+  }
+
+  private val self = this
+
+  private val ResolvedDependency.asDependency: Dependency?
+    get() =
+      when (this) {
+        is LocalDependency -> {
+          val localPath = projectDir.resolve(path)
+          if (Files.exists(localPath)) LocalProjectDependency(uri, localPath) else null
+        }
+        else -> {
+          this as RemoteDependency
+          PackageDependency(uri, self, checksums)
+        }
+      }
+}

--- a/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
+++ b/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
@@ -17,6 +17,7 @@ package org.pkl.lsp.resolvers
 
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.ast.*
+import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.type.Type
 import org.pkl.lsp.type.TypeParameterBindings
 import org.pkl.lsp.type.computeThisType
@@ -35,6 +36,7 @@ object Resolvers {
     moduleName: String,
     // receives elements of type PklTypeDef, PklImport, and PklTypeParameter
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): R {
 
     val enclosingModule = position.enclosingModule ?: return visitor.result
@@ -42,8 +44,8 @@ object Resolvers {
     for (import in enclosingModule.imports) {
       if (import.memberName == moduleName) {
         val importedModule =
-          import.resolve() as? SimpleModuleResolutionResult ?: return visitor.result
-        importedModule.resolved?.cache?.visitTypes(visitor)
+          import.resolve(context) as? SimpleModuleResolutionResult ?: return visitor.result
+        importedModule.resolved?.cache(context)?.visitTypes(visitor, context)
         return visitor.result
       }
     }
@@ -57,18 +59,20 @@ object Resolvers {
     bindings: TypeParameterBindings,
     // receives elements of type PklTypeDef, PklImport, and PklTypeParameter
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): R {
 
     // search type parameters of enclosing method
     val method = position.parentOfType<PklClassMethod>()
     if (method != null) {
-      if (!method.methodHeader.typeParameterList.visit(mapOf(), visitor)) return visitor.result
+      if (!method.methodHeader.typeParameterList.visit(mapOf(), visitor, context))
+        return visitor.result
     }
 
     // search type parameters of enclosing class or type alias
     val typeDef = position.parentOfTypes(PklTypeDef::class)
     if (typeDef != null) {
-      if (!typeDef.typeParameterList.visit(bindings, visitor)) return visitor.result
+      if (!typeDef.typeParameterList.visit(bindings, visitor, context)) return visitor.result
     }
 
     // search enclosing module
@@ -77,21 +81,22 @@ object Resolvers {
       for (import in module.imports) {
         // globs do not import a type
         if (import.isGlob) continue
-        if (!visitor.visitIfNotNull(import.memberName, import, mapOf())) return visitor.result
+        if (!visitor.visitIfNotNull(import.memberName, import, mapOf(), context))
+          return visitor.result
       }
       for (member in module.typeDefs) {
-        if (!visitor.visitIfNotNull(member.name, member, mapOf())) return visitor.result
+        if (!visitor.visitIfNotNull(member.name, member, mapOf(), context)) return visitor.result
       }
 
       // search supermodules
-      val supermodule = module.supermodule
+      val supermodule = module.supermodule(context)
       if (supermodule != null) {
-        if (!supermodule.cache.visitTypes(visitor)) return visitor.result
+        if (!supermodule.cache(context).visitTypes(visitor, context)) return visitor.result
       }
     }
 
     // search pkl.base
-    base.ctx.cache.visitTypes(visitor)
+    base.ctx.cache(null).visitTypes(visitor, context)
     return visitor.result
   }
 
@@ -105,9 +110,19 @@ object Resolvers {
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): R {
 
-    return resolveUnqualifiedAccess(position, thisType, isProperty, true, base, bindings, visitor)
+    return resolveUnqualifiedAccess(
+      position,
+      thisType,
+      isProperty,
+      true,
+      base,
+      bindings,
+      visitor,
+      context,
+    )
   }
 
   fun <R> resolveUnqualifiedAccess(
@@ -120,13 +135,22 @@ object Resolvers {
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): R {
 
     return if (isProperty) {
-      resolveUnqualifiedVariableAccess(position, thisType, base, bindings, allowClasses, visitor)
+      resolveUnqualifiedVariableAccess(
+          position,
+          thisType,
+          base,
+          bindings,
+          allowClasses,
+          visitor,
+          context,
+        )
         .first
     } else {
-      resolveUnqualifiedMethodAccess(position, thisType, base, bindings, visitor).first
+      resolveUnqualifiedMethodAccess(position, thisType, base, bindings, visitor, context).first
     }
   }
 
@@ -140,11 +164,20 @@ object Resolvers {
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): Pair<R, LookupMode> {
     return if (isProperty) {
-      resolveUnqualifiedVariableAccess(position, thisType, base, bindings, allowClasses, visitor)
+      resolveUnqualifiedVariableAccess(
+        position,
+        thisType,
+        base,
+        bindings,
+        allowClasses,
+        visitor,
+        context,
+      )
     } else {
-      resolveUnqualifiedMethodAccess(position, thisType, base, bindings, visitor)
+      resolveUnqualifiedMethodAccess(position, thisType, base, bindings, visitor, context)
     }
   }
 
@@ -154,21 +187,23 @@ object Resolvers {
     isProperty: Boolean,
     base: PklBaseModule,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): R {
 
-    receiverType.visitMembers(isProperty, allowClasses = true, base, visitor)
+    receiverType.visitMembers(isProperty, allowClasses = true, base, visitor, context)
     return visitor.result
   }
 
   private fun PklTypeParameterList?.visit(
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<*>,
+    context: PklProject?,
   ): Boolean {
     if (this == null) return true
 
     for (parameter in typeParameters) {
       val parameterName = parameter.identifier!!.text
-      if (!visitor.visit(parameterName, parameter, bindings)) return false
+      if (!visitor.visit(parameterName, parameter, bindings, context)) return false
     }
 
     return true
@@ -181,6 +216,7 @@ object Resolvers {
     bindings: TypeParameterBindings,
     allowClasses: Boolean,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): Pair<R, LookupMode> {
 
     var element: PklNode? = position
@@ -190,13 +226,14 @@ object Resolvers {
       when (element) {
         is PklExpr -> {
           if (element is PklFunctionLiteralExpr) {
-            val functionType = element.inferExprTypeFromContext(base, bindings)
+            val functionType = element.inferExprTypeFromContext(base, bindings, context)
             for (parameter in element.parameterList.elements) {
               if (
                 !visitor.visitIfNotNull(
                   parameter.typedIdentifier?.identifier?.text,
                   parameter.typedIdentifier,
                   functionType.bindings,
+                  context,
                 )
               )
                 return visitor.result to LookupMode.LEXICAL
@@ -214,7 +251,7 @@ object Resolvers {
             is PklLetExpr -> {
               if (element == parent.bodyExpr) {
                 parent.parameter?.typedIdentifier?.let { typedId ->
-                  if (!visitor.visitIfNotNull(typedId.identifier?.text, typedId, bindings))
+                  if (!visitor.visitIfNotNull(typedId.identifier?.text, typedId, bindings, context))
                     return visitor.result to LookupMode.LEXICAL
                 }
               }
@@ -224,13 +261,13 @@ object Resolvers {
               when {
                 element == parent.thenExpr -> {
                   parent.conditionExpr.let { condExpr ->
-                    if (!visitSatisfiedCondition(condExpr, bindings, visitor))
+                    if (!visitSatisfiedCondition(condExpr, bindings, visitor, context))
                       return visitor.result to LookupMode.NONE
                   }
                 }
                 element == parent.elseExpr -> {
                   parent.conditionExpr.let { condExpr ->
-                    if (!visitUnsatisfiedCondition(condExpr, bindings, visitor))
+                    if (!visitUnsatisfiedCondition(condExpr, bindings, visitor, context))
                       return visitor.result to LookupMode.NONE
                   }
                 }
@@ -239,14 +276,14 @@ object Resolvers {
             // flow typing of `expr && ...`
             is PklLogicalAndExpr -> {
               if (element == parent.rightExpr) {
-                if (!visitSatisfiedCondition(parent.leftExpr, bindings, visitor))
+                if (!visitSatisfiedCondition(parent.leftExpr, bindings, visitor, context))
                   return visitor.result to LookupMode.NONE
               }
             }
             // flow typing of `expr || ...`
             is PklLogicalOrExpr -> {
               if (element == parent.rightExpr) {
-                if (!visitUnsatisfiedCondition(parent.leftExpr, bindings, visitor))
+                if (!visitUnsatisfiedCondition(parent.leftExpr, bindings, visitor, context))
                   return visitor.result to LookupMode.NONE
               }
             }
@@ -257,7 +294,7 @@ object Resolvers {
             skipNextObjectBody = false
           } else {
             for (member in element.properties) {
-              if (!visitor.visitIfNotNull(member.name, member, bindings))
+              if (!visitor.visitIfNotNull(member.name, member, bindings, context))
                 return visitor.result to LookupMode.LEXICAL
             }
             element.parameterList.elements.let { parameterList ->
@@ -267,6 +304,7 @@ object Resolvers {
                     parameter.typedIdentifier?.identifier?.text,
                     parameter.typedIdentifier,
                     bindings,
+                    context,
                   )
                 )
                   return visitor.result to LookupMode.LEXICAL
@@ -280,13 +318,13 @@ object Resolvers {
             when {
               element == parent.thenBody -> {
                 parent.conditionExpr?.let { condExpr ->
-                  if (!visitSatisfiedCondition(condExpr, bindings, visitor))
+                  if (!visitSatisfiedCondition(condExpr, bindings, visitor, context))
                     return visitor.result to LookupMode.NONE
                 }
               }
               element == parent.elseBody -> {
                 parent.conditionExpr?.let { condExpr ->
-                  if (!visitUnsatisfiedCondition(condExpr, bindings, visitor))
+                  if (!visitUnsatisfiedCondition(condExpr, bindings, visitor, context))
                     return visitor.result to LookupMode.NONE
                 }
               }
@@ -295,7 +333,7 @@ object Resolvers {
         }
         is PklForGenerator -> {
           for (typedId in element.parameters.mapNotNull { it.typedIdentifier }) {
-            if (!visitor.visitIfNotNull(typedId.identifier?.text, typedId, bindings))
+            if (!visitor.visitIfNotNull(typedId.identifier?.text, typedId, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
@@ -307,6 +345,7 @@ object Resolvers {
                   parameter.typedIdentifier?.identifier?.text,
                   parameter.typedIdentifier,
                   bindings,
+                  context,
                 )
               )
                 return visitor.result to LookupMode.LEXICAL
@@ -315,18 +354,18 @@ object Resolvers {
         }
         is PklClass -> {
           for (property in element.properties) {
-            if (!visitor.visitIfNotNull(property.name, property, bindings))
+            if (!visitor.visitIfNotNull(property.name, property, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
         is PklModule -> {
           for (import in element.imports) {
-            if (!visitor.visitIfNotNull(import.memberName, import, bindings))
+            if (!visitor.visitIfNotNull(import.memberName, import, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
           val members = if (allowClasses) element.typeDefsAndProperties else element.properties
           for (member in members) {
-            if (!visitor.visitIfNotNull(member.name, member, bindings))
+            if (!visitor.visitIfNotNull(member.name, member, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
@@ -336,14 +375,15 @@ object Resolvers {
 
     // if resolve happens within base module, this is a redundant lookup, but it shouldn't hurt
     if (allowClasses) {
-      if (!base.ctx.cache.visitTypeDefsAndProperties(visitor))
+      if (!base.ctx.cache(null).visitTypeDefsAndProperties(visitor, context))
         return visitor.result to LookupMode.BASE
     } else {
-      if (!base.ctx.cache.visitProperties(visitor)) return visitor.result to LookupMode.BASE
+      if (!base.ctx.cache(null).visitProperties(visitor, context))
+        return visitor.result to LookupMode.BASE
     }
 
-    val myThisType = thisType ?: position.computeThisType(base, bindings)
-    myThisType.visitMembers(isProperty = true, allowClasses, base, visitor)
+    val myThisType = thisType ?: position.computeThisType(base, bindings, context)
+    myThisType.visitMembers(isProperty = true, allowClasses, base, visitor, context)
 
     return visitor.result to LookupMode.IMPLICIT_THIS
   }
@@ -353,6 +393,7 @@ object Resolvers {
     expr: PklExpr,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<*>,
+    context: PklProject?,
   ): Boolean {
     if (visitor !is FlowTypingResolveVisitor<*>) return true
 
@@ -363,9 +404,9 @@ object Resolvers {
         if (expr.operator == TypeTestOperator.AS) {
           true
         } else if (leftExpr is PklUnqualifiedAccessExpr && leftExpr.isPropertyAccess) {
-          visitor.visitHasType(leftExpr.memberNameText, expr.type, bindings, false)
+          visitor.visitHasType(leftExpr.memberNameText, expr.type, bindings, false, context)
         } else if (leftExpr is PklThisExpr) {
-          visitor.visitHasType(leftExpr.text, expr.type, bindings, false)
+          visitor.visitHasType(leftExpr.text, expr.type, bindings, false, context)
         } else true
       }
       // foo != null, null != foo
@@ -378,13 +419,13 @@ object Resolvers {
               leftExpr.isPropertyAccess &&
               expr.rightExpr is PklNullLiteralExpr
           ) {
-            visitor.visitEqualsConstant(leftExpr.memberNameText, null, true)
+            visitor.visitEqualsConstant(leftExpr.memberNameText, null, true, context)
           } else if (
             rightExpr is PklUnqualifiedAccessExpr &&
               rightExpr.isPropertyAccess &&
               expr.leftExpr is PklNullLiteralExpr
           ) {
-            visitor.visitEqualsConstant(rightExpr.memberNameText, null, true)
+            visitor.visitEqualsConstant(rightExpr.memberNameText, null, true, context)
           } else true
         } else true
       }
@@ -402,16 +443,16 @@ object Resolvers {
         // and use cases for `foo != null && foo is Foo?`
         // (or `if (foo != null) if (foo is Foo?)`) are limited.
         val rightExpr = expr.rightExpr
-        (visitSatisfiedCondition(rightExpr, bindings, visitor)) &&
-          visitSatisfiedCondition(expr.leftExpr, bindings, visitor)
+        (visitSatisfiedCondition(rightExpr, bindings, visitor, context)) &&
+          visitSatisfiedCondition(expr.leftExpr, bindings, visitor, context)
       }
       is PklLogicalNotExpr -> {
         val childExpr = expr.expr
-        visitUnsatisfiedCondition(childExpr, bindings, visitor)
+        visitUnsatisfiedCondition(childExpr, bindings, visitor, context)
       }
       is PklParenthesizedExpr -> {
         val childExpr = expr.expr
-        childExpr == null || visitSatisfiedCondition(childExpr, bindings, visitor)
+        childExpr == null || visitSatisfiedCondition(childExpr, bindings, visitor, context)
       }
       else -> true
     }
@@ -422,6 +463,7 @@ object Resolvers {
     expr: PklExpr,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<*>,
+    context: PklProject?,
   ): Boolean {
     if (visitor !is FlowTypingResolveVisitor<*>) return true
 
@@ -430,9 +472,9 @@ object Resolvers {
       is PklTypeTestExpr -> {
         val leftExpr = expr.expr
         if (leftExpr is PklUnqualifiedAccessExpr && leftExpr.isPropertyAccess) {
-          visitor.visitHasType(leftExpr.memberNameText, expr.type, bindings, true)
+          visitor.visitHasType(leftExpr.memberNameText, expr.type, bindings, true, context)
         } else if (leftExpr is PklThisExpr) {
-          visitor.visitHasType(leftExpr.text, expr.type, bindings, true)
+          visitor.visitHasType(leftExpr.text, expr.type, bindings, true, context)
         } else true
       }
       // foo == null -negated-> foo != null
@@ -446,31 +488,31 @@ object Resolvers {
               leftExpr.isPropertyAccess &&
               expr.rightExpr is PklNullLiteralExpr
           ) {
-            visitor.visitEqualsConstant(leftExpr.memberNameText, null, true)
+            visitor.visitEqualsConstant(leftExpr.memberNameText, null, true, context)
           } else if (
             rightExpr is PklUnqualifiedAccessExpr &&
               rightExpr.isPropertyAccess &&
               expr.leftExpr is PklNullLiteralExpr
           ) {
-            visitor.visitEqualsConstant(rightExpr.memberNameText, null, true)
+            visitor.visitEqualsConstant(rightExpr.memberNameText, null, true, context)
           } else true
         } else true
       }
       // leftExpr || rightExpr -negated-> !leftExpr && !rightExpr
       is PklLogicalOrExpr -> {
         val rightExpr = expr.rightExpr
-        (visitUnsatisfiedCondition(rightExpr, bindings, visitor)) &&
-          visitUnsatisfiedCondition(expr.leftExpr, bindings, visitor)
+        (visitUnsatisfiedCondition(rightExpr, bindings, visitor, context)) &&
+          visitUnsatisfiedCondition(expr.leftExpr, bindings, visitor, context)
       }
       // !expr -negated-> expr
       is PklLogicalNotExpr -> {
         val childExpr = expr.expr
-        visitSatisfiedCondition(childExpr, bindings, visitor)
+        visitSatisfiedCondition(childExpr, bindings, visitor, context)
       }
       // (expr) -negated-> !expr
       is PklParenthesizedExpr -> {
         val childExpr = expr.expr
-        childExpr == null || visitUnsatisfiedCondition(childExpr, bindings, visitor)
+        childExpr == null || visitUnsatisfiedCondition(childExpr, bindings, visitor, context)
       }
       else -> true
     }
@@ -482,6 +524,7 @@ object Resolvers {
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     visitor: ResolveVisitor<R>,
+    context: PklProject?,
   ): Pair<R, LookupMode> {
 
     var element: PklNode? = position
@@ -490,19 +533,19 @@ object Resolvers {
       when (element) {
         is PklObjectBody -> {
           for (member in element.methods) {
-            if (!visitor.visitIfNotNull(member.name, member, bindings))
+            if (!visitor.visitIfNotNull(member.name, member, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
         is PklClass -> {
           for (method in element.methods) {
-            if (!visitor.visitIfNotNull(method.name, method, bindings))
+            if (!visitor.visitIfNotNull(method.name, method, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
         is PklModule -> {
           for (method in element.methods) {
-            if (!visitor.visitIfNotNull(method.name, method, bindings))
+            if (!visitor.visitIfNotNull(method.name, method, bindings, context))
               return visitor.result to LookupMode.LEXICAL
           }
         }
@@ -511,10 +554,11 @@ object Resolvers {
     }
 
     // if resolve happens within base module, this is a redundant lookup, but it shouldn't hurt
-    if (!base.ctx.cache.visitMethods(visitor)) return visitor.result to LookupMode.BASE
+    if (!base.ctx.cache(context).visitMethods(visitor, context))
+      return visitor.result to LookupMode.BASE
 
-    val myThisType = thisType ?: position.computeThisType(base, bindings)
-    myThisType.visitMembers(isProperty = false, allowClasses = true, base, visitor)
+    val myThisType = thisType ?: position.computeThisType(base, bindings, context)
+    myThisType.visitMembers(isProperty = false, allowClasses = true, base, visitor, context)
 
     return visitor.result to LookupMode.IMPLICIT_THIS
   }

--- a/src/main/kotlin/org/pkl/lsp/services/MessageBus.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/MessageBus.kt
@@ -1,0 +1,44 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.services
+
+import java.util.concurrent.ConcurrentHashMap
+import org.pkl.lsp.Component
+import org.pkl.lsp.Project
+
+data class Topic<T : Any>(val name: String)
+
+class MessageBus(project: Project) : Component(project) {
+  private val observers: MutableMap<Topic<*>, MutableList<(Any) -> Unit>> = ConcurrentHashMap()
+
+  /** Subscribe to events fired on [topic]. */
+  fun <T : Any> subscribe(topic: Topic<T>, observer: (T) -> Unit) =
+    synchronized(this) {
+      val list = observers.computeIfAbsent(topic) { ArrayList() }
+      @Suppress("UNCHECKED_CAST") list.add(observer as (Any) -> Unit)
+    }
+
+  /** Emit an event on [topic]. */
+  fun <T : Any> emit(topic: Topic<T>, event: T) =
+    synchronized(this) {
+      val observers = observers[topic] ?: return
+      for (observer in observers) {
+        observer(event)
+      }
+    }
+
+  override fun dispose() = synchronized(this) { observers.clear() }
+}

--- a/src/main/kotlin/org/pkl/lsp/services/PackageManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PackageManager.kt
@@ -51,9 +51,6 @@ class PackageManager(project: Project) : Component(project) {
   fun getLibraryRoots(dependency: PackageDependency): PackageLibraryRoots? =
     project.cachedValuesManager.getCachedValue("library-roots-${dependency.packageUri}") {
       logger.info("Getting library roots for ${dependency.packageUri}")
-      if (pklCacheDir == null) {
-        return@getCachedValue null
-      }
       val metadataFile =
         dependency.packageUri.relativeMetadataFiles.firstNotNullOfOrNull {
           pklCacheDir.resolve(it).toVirtualFile()

--- a/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
@@ -115,9 +115,7 @@ class PklProjectManager(project: Project) : Component(project) {
           val pklProject = PklProject(metadata, resolvedDeps)
           pklProjects[key] = pklProject
           lastPklProjectSyncState[key] = projectFile.getModificationCount()
-          if (pklCacheDir != null) {
-            doDownloadDependencies(pklProject, pklCacheDir)
-          }
+          doDownloadDependencies(pklProject, pklCacheDir)
         }
         persistState()
         project.languageClient.showMessage(

--- a/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
@@ -93,7 +93,7 @@ class PklProjectManager(project: Project) : Component(project) {
     }
   }
 
-  fun syncProjects(): CompletableFuture<Unit> {
+  fun syncProjects(emitEvents: Boolean = false): CompletableFuture<Unit> {
     val pklProjectFiles = discoverProjectFiles()
     if (pklProjectFiles.isEmpty()) {
       pklProjects.clear()
@@ -123,7 +123,9 @@ class PklProjectManager(project: Project) : Component(project) {
         project.languageClient.showMessage(
           MessageParams(MessageType.Info, "Project sync successful")
         )
-        project.messageBus.emit(projectTopic, ProjectEvent(ProjectEventType.PROJECTS_SYNCED))
+        if (emitEvents) {
+          project.messageBus.emit(projectTopic, ProjectEvent(ProjectEventType.PROJECTS_SYNCED))
+        }
       }
       .exceptionally { err ->
         project.languageClient.showMessage(

--- a/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
@@ -1,0 +1,343 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.services
+
+import java.net.URI
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.io.path.absolutePathString
+import kotlin.io.path.name
+import org.eclipse.lsp4j.*
+import org.pkl.lsp.*
+import org.pkl.lsp.FsFile
+import org.pkl.lsp.VirtualFile
+import org.pkl.lsp.messages.ActionableNotification
+import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.packages.dto.PklProject.Companion.DerivedProjectMetadata
+import org.pkl.lsp.packages.dto.RemoteDependency
+import org.pkl.lsp.util.FileCacheManager.Companion.pklCacheDir
+import org.pkl.lsp.util.SimpleModificationTracker
+
+val projectTopic = Topic<ProjectEvent>("ProjectEvent")
+
+data class ProjectEvent(val type: ProjectEventType)
+
+enum class ProjectEventType {
+  PROJECTS_SYNCED
+}
+
+class PklProjectManager(project: Project) : Component(project) {
+  companion object {
+    const val PKL_PROJECT_FILENAME = "PklProject"
+    const val PKL_PROJECT_DEPS_FILENAME = "PklProject.deps.json"
+    const val PKL_PROJECT_STATE_FILENAME = "projects.json"
+    const val PKL_LSP_DIR = ".pkl-lsp"
+
+    private const val DEPENDENCIES_EXPR =
+      """
+      new JsonRenderer { omitNullProperties = false }
+        .renderValue(new Dynamic {
+          projectFileUri = module.projectFileUri
+          packageUri = module.package?.uri
+          declaredDependencies = module.dependencies.toMap().mapValues((_, value) ->
+            if (value is RemoteDependency) value.uri
+            else value.package.uri
+          )
+          evaluatorSettings = module.evaluatorSettings
+        })
+      """
+  }
+
+  /**
+   * Returns the PklProject associated with the provided [file].
+   *
+   * [file] is either a directory, or a PklProject file.
+   */
+  fun getPklProject(file: VirtualFile): PklProject? =
+    if (file !is FsFile) null else pklProjects[file.projectKey]
+
+  /** Tracks when PklProject files get added or deleted from the workspace. */
+  val addedOrRemovedFilesModificationTracker = SimpleModificationTracker()
+
+  /** Tracks when projects get sync'd. */
+  val syncTracker = SimpleModificationTracker()
+
+  fun initialize(folders: List<Path>?) {
+    project.messageBus.subscribe(textDocumentTopic, ::handleTextDocumentEvent)
+    project.messageBus.subscribe(workspaceFolderTopic, ::handleWorkspaceFolderEvent)
+    project.messageBus.subscribe(workspaceTopic, ::handleWorkspaceEvent)
+    workspaceFolders.clear()
+    pklProjects.clear()
+    lastPklProjectSyncState.clear()
+    if (folders != null) {
+      workspaceFolders.addAll(folders)
+      loadState()
+    }
+  }
+
+  fun syncProjects(): CompletableFuture<Unit> {
+    val pklProjectFiles = discoverProjectFiles()
+    if (pklProjectFiles.isEmpty()) {
+      pklProjects.clear()
+      lastPklProjectSyncState.clear()
+      return CompletableFuture.completedFuture(Unit)
+    }
+    return project.pklCli
+      .resolveProject(pklProjectFiles.map { it.path.parent })
+      .thenCompose { getProjectMetadatas(pklProjectFiles) }
+      .thenApply { metadatas ->
+        pklProjects.clear()
+        lastPklProjectSyncState.clear()
+        for (metadata in metadatas) {
+          val projectFile = project.virtualFileManager.getFsFile(metadata.projectFileUri)!!
+          val key = projectFile.projectKey
+          val projectDir = projectFile.parent()!!
+          val resolvedDepsPath = projectDir.resolve(PKL_PROJECT_DEPS_FILENAME)
+          val resolvedDeps = resolvedDepsPath?.let { PklProject.loadProjectDeps(it) }
+          val pklProject = PklProject(metadata, resolvedDeps)
+          pklProjects[key] = pklProject
+          lastPklProjectSyncState[key] = projectFile.getModificationCount()
+          if (pklCacheDir != null) {
+            doDownloadDependencies(pklProject, pklCacheDir)
+          }
+        }
+        persistState()
+        project.languageClient.showMessage(
+          MessageParams(MessageType.Info, "Project sync successful")
+        )
+        project.messageBus.emit(projectTopic, ProjectEvent(ProjectEventType.PROJECTS_SYNCED))
+      }
+      .exceptionally { err ->
+        project.languageClient.showMessage(
+          MessageParams(
+            MessageType.Error,
+            """
+        Failed to sync project.
+        
+        ${err.cause!!.stackTraceToString()}
+      """
+              .trimIndent(),
+          )
+        )
+      }
+      .whenComplete { _, _ -> syncTracker.increment() }
+  }
+
+  /** All workspace folders managed by the client. */
+  private val workspaceFolders: MutableSet<Path> = mutableSetOf()
+
+  /** All projects, keyed by the project directory. */
+  private val pklProjects: MutableMap<URI, PklProject> = ConcurrentHashMap()
+
+  /**
+   * The modification count of each project file during the last sync, keyed by the project
+   * directory.
+   */
+  private val lastPklProjectSyncState: MutableMap<URI, Long> = ConcurrentHashMap()
+
+  private val FsFile.projectKey
+    get(): URI =
+      if (name == PKL_PROJECT_FILENAME) this.path.toUri()
+      else this.path.resolve(PKL_PROJECT_FILENAME).toUri()
+
+  private fun isPklProjectFileClean(file: FsFile): Boolean =
+    file.getModificationCount() == lastPklProjectSyncState[file.projectKey]
+
+  private fun handleTextDocumentEvent(event: TextDocumentEvent) {
+    val file = project.virtualFileManager.getFsFile(event.file) ?: return
+    if (
+      file.path.endsWith("PklProject") &&
+        event.type == TextDocumentEventType.SAVED &&
+        file.pklProject != null &&
+        !isPklProjectFileClean(file)
+    ) {
+      project.languageClient.sendActionableNotification(
+        ActionableNotification(
+          type = MessageType.Info,
+          message = ErrorMessages.create("pklProjectFileModified"),
+          commands = listOf(Command("Sync projects", "pkl.syncProjects")),
+        )
+      )
+    }
+    if (
+      event.type == TextDocumentEventType.OPENED &&
+        file.pklProjectDir != null &&
+        file.pklProject == null
+    ) {
+      project.languageClient.sendActionableNotification(
+        ActionableNotification(
+          type = MessageType.Info,
+          message = ErrorMessages.create("unsyncedPklProject"),
+          commands = listOf(Command("Sync projects", "pkl.syncProjects")),
+        )
+      )
+    }
+  }
+
+  private fun handleWorkspaceFolderEvent(event: WorkspaceFoldersChangeEvent) =
+    synchronized(this) {
+      for (workspaceFolder in event.added) {
+        val path = Path.of(URI(workspaceFolder.uri))
+        workspaceFolders.add(path)
+        loadWorkspaceState(path)
+      }
+      for (workspaceFolder in event.removed) {
+        val path = Path.of(URI(workspaceFolder.uri))
+        workspaceFolders.removeIf { it.toUri() == path.toUri() }
+        unloadWorkspaceState(path)
+      }
+      project.messageBus.emit(projectTopic, ProjectEvent(ProjectEventType.PROJECTS_SYNCED))
+    }
+
+  private fun handleWorkspaceEvent(event: WorkspaceEvent) {
+    if (event.files.any { it.path.endsWith("PklProject") }) {
+      addedOrRemovedFilesModificationTracker.increment()
+    }
+  }
+
+  private fun doDownloadDependencies(pklProject: PklProject, cacheDir: Path) {
+    val packageUris =
+      pklProject.projectDeps
+        ?.resolvedDependencies
+        ?.values
+        ?.filterIsInstance<RemoteDependency>()
+        ?.map { it.uri.copy(checksums = it.checksums) }
+        ?.ifEmpty { null } ?: return
+    project.pklCli
+      .downloadPackage(
+        packageUris,
+        cacheDir = cacheDir,
+        // All transitive dependencies are already declared in PklProject.deps.json
+        noTransitive = true,
+      )
+      .get()
+  }
+
+  private fun getProjectMetadatas(
+    projectFiles: List<FsFile>
+  ): CompletableFuture<List<DerivedProjectMetadata>> {
+    return project.pklCli
+      .eval(
+        projectFiles.map { it.path.absolutePathString() },
+        expression = DEPENDENCIES_EXPR,
+        moduleOutputSeparator = ", ",
+      )
+      .thenApply { PklProject.parseMetadata("[$it]") }
+  }
+
+  private fun discoverProjectFiles(): List<FsFile> {
+    return workspaceFolders.flatMap { folderRoot ->
+      buildList {
+        Files.walkFileTree(
+          folderRoot,
+          object : SimpleFileVisitor<Path>() {
+            override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+              if (file.name == PKL_PROJECT_FILENAME) {
+                add(project.virtualFileManager.getFsFile(file)!!)
+              }
+              return FileVisitResult.CONTINUE
+            }
+          },
+        )
+      }
+    }
+  }
+
+  private fun persistState() {
+    val projectsByWorkspaceDir =
+      pklProjects.values.groupBy { pklProject ->
+        workspaceFolders.find { pklProject.projectDir.startsWith(it) }!!
+      }
+    for ((workspace, pklProjects) in projectsByWorkspaceDir) {
+      val state =
+        PklWorkspaceState(
+          schemaVersion = 1,
+          pklProjects = pklProjects.map { it.toState(workspace) },
+        )
+      val lspDir = workspace.resolve(PKL_LSP_DIR)
+      Files.createDirectories(lspDir)
+      state.dump(lspDir.resolve(PKL_PROJECT_STATE_FILENAME))
+    }
+  }
+
+  private fun loadWorkspaceState(workspace: Path) {
+    val stateFile = workspace.resolve(PKL_LSP_DIR).resolve(PKL_PROJECT_STATE_FILENAME)
+    if (!Files.exists(stateFile)) {
+      return
+    }
+    val state: PklWorkspaceState = PklWorkspaceState.load(stateFile)
+    logger.log("Decoded state: $state")
+    for (pklProjectState in state.pklProjects) {
+      val pklProject = loadProjectFromState(pklProjectState, workspace)
+      val projectFile = project.virtualFileManager.getFsFile(pklProject.metadata.projectFileUri)!!
+      pklProjects[projectFile.projectKey] = pklProject
+      lastPklProjectSyncState[projectFile.projectKey] = projectFile.getModificationCount()
+    }
+  }
+
+  private fun unloadWorkspaceState(workspace: Path) {
+    val myProjects = pklProjects.values.filter { it.projectDir.startsWith(workspace) }
+    for (pklProject in myProjects) {
+      val projectFile = project.virtualFileManager.getFsFile(pklProject.metadata.projectFileUri)!!
+      pklProjects.remove(projectFile.projectKey)
+      lastPklProjectSyncState.remove(projectFile.projectKey)
+    }
+  }
+
+  private fun loadState() {
+    pklProjects.clear()
+    lastPklProjectSyncState.clear()
+    for (workspace in workspaceFolders) {
+      try {
+        loadWorkspaceState(workspace)
+      } catch (e: Throwable) {
+        logger.warn("Failed to load state from $workspace")
+        logger.warn(e.stackTraceToString())
+      }
+    }
+    project.messageBus.emit(projectTopic, ProjectEvent(ProjectEventType.PROJECTS_SYNCED))
+  }
+
+  private fun loadProjectFromState(pklProjectState: PklProjectState, workspace: Path): PklProject {
+    val metadata =
+      DerivedProjectMetadata(
+        workspace.resolve(pklProjectState.projectFile).toUri(),
+        pklProjectState.packageUri,
+        pklProjectState.declaredDependencies,
+        pklProjectState.evaluatorSettings,
+      )
+    val projectDeps =
+      if (pklProjectState.resolvedDependencies?.isNotEmpty() == true)
+        PklProject.Companion.ProjectDeps(1, pklProjectState.resolvedDependencies)
+      else null
+    return PklProject(metadata, projectDeps)
+  }
+
+  private fun PklProject.toState(workspace: Path): PklProjectState {
+    return PklProjectState(
+      projectFile = workspace.relativize(projectFile).normalize().toUnixPathString(),
+      packageUri = metadata.packageUri,
+      declaredDependencies = metadata.declaredDependencies,
+      resolvedDependencies = projectDeps?.resolvedDependencies,
+      evaluatorSettings = metadata.evaluatorSettings,
+    )
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/services/PklProjectState.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PklProjectState.kt
@@ -1,0 +1,54 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.services
+
+import java.nio.file.Path
+import kotlin.io.path.inputStream
+import kotlin.io.path.outputStream
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.json.encodeToStream
+import org.pkl.lsp.packages.dto.PackageUri
+import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.packages.dto.ResolvedDependency
+
+@OptIn(ExperimentalSerializationApi::class)
+@Serializable
+data class PklWorkspaceState(val schemaVersion: Int, val pklProjects: List<PklProjectState>) {
+  companion object {
+    private val json = Json {
+      ignoreUnknownKeys = true
+      prettyPrint = true
+      prettyPrintIndent = "  "
+      classDiscriminator = "myType"
+    }
+
+    fun load(file: Path): PklWorkspaceState = json.decodeFromStream(file.inputStream())
+  }
+
+  fun dump(file: Path) = json.encodeToStream(this, file.outputStream())
+}
+
+@Serializable
+data class PklProjectState(
+  val projectFile: String,
+  val packageUri: PackageUri?,
+  val declaredDependencies: Map<String, PackageUri>,
+  val resolvedDependencies: Map<String, ResolvedDependency>?,
+  val evaluatorSettings: PklProject.Companion.EvaluatorSettings?,
+)

--- a/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
@@ -17,16 +17,29 @@ package org.pkl.lsp.services
 
 import com.google.gson.JsonPrimitive
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
 import kotlinx.serialization.Serializable
+import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.ConfigurationItem
 import org.eclipse.lsp4j.ConfigurationParams
-import org.pkl.lsp.Component
-import org.pkl.lsp.Project
+import org.eclipse.lsp4j.MessageType
+import org.pkl.lsp.*
+import org.pkl.lsp.messages.ActionableNotification
 
 @Serializable data class WorkspaceSettings(var pklCliPath: Path? = null)
 
 class SettingsManager(project: Project) : Component(project) {
   var settings: WorkspaceSettings = WorkspaceSettings()
+  private var initialized: CompletableFuture<Unit> = CompletableFuture()
+
+  override fun initialize() {
+    loadSettings()
+    project.messageBus.subscribe(textDocumentTopic, ::handleTextDocumentEvent)
+  }
+
+  override fun dispose() {
+    initialized = CompletableFuture()
+  }
 
   fun loadSettings() {
     logger.log("Fetching configuration")
@@ -41,16 +54,40 @@ class SettingsManager(project: Project) : Component(project) {
       )
     project.languageClient
       .configuration(params)
-      .thenApply { response ->
-        logger.log("Got $response from configuration request")
-        val cliPath = response[0] as JsonPrimitive
-        if (!cliPath.isString) {
-          logger.log("Got non-string value for configuration: $cliPath")
+      .thenApply { (cliPath) ->
+        logger.log("Got configuration: $cliPath")
+        cliPath as JsonPrimitive
+        if (cliPath.isJsonNull) {
+          settings.pklCliPath = null
           return@thenApply
         }
-        settings.pklCliPath = Path.of(cliPath.asString)
-        logger.log("Loaded settings: $settings")
+        if (!cliPath.isString) {
+          logger.warn("Got non-string value for configuration: $cliPath")
+          return@thenApply
+        }
+        settings.pklCliPath = cliPath.asString.let { if (it.isEmpty()) null else Path.of(it) }
       }
-      .exceptionally { err -> logger.error("Failed to fetch configuration: ${err.cause}") }
+      .exceptionally { logger.error("Failed to fetch settings: ${it.cause}") }
+      .whenComplete { _, _ ->
+        logger.log("Settings changed to $settings")
+        initialized.complete(Unit)
+      }
+  }
+
+  private fun handleTextDocumentEvent(event: TextDocumentEvent) {
+    if (event.type != TextDocumentEventType.OPENED) return
+    val file = project.virtualFileManager.getFsFile(event.file) ?: return
+    initialized.whenComplete { _, _ ->
+      if (settings.pklCliPath == null && file.pklProjectDir != null) {
+        project.languageClient.sendActionableNotification(
+          ActionableNotification(
+            type = MessageType.Info,
+            message = "Pkl CLI is not configured",
+            commands =
+              listOf(Command("Configure CLI path", "pkl.configure", listOf("pkl.cli.path"))),
+          )
+        )
+      }
+    }
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -19,13 +19,15 @@ import java.util.*
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*
+import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitor
 import org.pkl.lsp.unexpectedType
 
 sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
   companion object {
     fun alias(
-      ctx: PklTypeAlias,
+      node: PklTypeAlias,
+      context: PklProject?,
       specifiedTypeArguments: List<Type> = listOf(),
       constraints: List<ConstraintExpr> = listOf(),
     ): Type =
@@ -33,18 +35,37 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       // where recursion is introduced via type argument:
       // typealias Alias<T> = T|Boolean
       // p: Alias<Alias<String>>
-      if (ctx.isRecursive) Unknown else Alias.unchecked(ctx, specifiedTypeArguments, constraints)
+      if (node.isRecursive(context)) Unknown
+      else Alias.unchecked(node, specifiedTypeArguments, constraints)
 
-    fun module(ctx: PklModule, referenceName: String): Module = Module.create(ctx, referenceName)
+    fun module(ctx: PklModule, referenceName: String, context: PklProject?): Module =
+      Module.create(ctx, referenceName, context)
 
-    fun union(type1: Type, type2: Type, base: PklBaseModule): Type =
-      Union.create(type1, type2, base)
+    fun union(type1: Type, type2: Type, base: PklBaseModule, context: PklProject?): Type =
+      Union.create(type1, type2, base, context)
 
-    fun union(type1: Type, type2: Type, type3: Type, base: PklBaseModule): Type =
-      Union.create(Union.create(type1, type2, base), type3, base)
+    fun union(
+      type1: Type,
+      type2: Type,
+      type3: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Type = Union.create(Union.create(type1, type2, base, context), type3, base, context)
 
-    fun union(type1: Type, type2: Type, type3: Type, type4: Type, base: PklBaseModule): Type =
-      Union.create(Union.create(Union.create(type1, type2, base), type3, base), type4, base)
+    fun union(
+      type1: Type,
+      type2: Type,
+      type3: Type,
+      type4: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Type =
+      Union.create(
+        Union.create(Union.create(type1, type2, base, context), type3, base, context),
+        type4,
+        base,
+        context,
+      )
 
     fun union(
       type1: Type,
@@ -53,11 +74,18 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       type4: Type,
       type5: Type,
       base: PklBaseModule,
+      context: PklProject?,
     ): Type =
       Union.create(
-        Union.create(Union.create(Union.create(type1, type2, base), type3, base), type4, base),
+        Union.create(
+          Union.create(Union.create(type1, type2, base, context), type3, base, context),
+          type4,
+          base,
+          context,
+        ),
         type5,
         base,
+        context,
       )
 
     fun union(
@@ -68,19 +96,27 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       type5: Type,
       type6: Type,
       base: PklBaseModule,
+      context: PklProject?,
     ): Type =
       Union.create(
         Union.create(
-          Union.create(Union.create(Union.create(type1, type2, base), type3, base), type4, base),
+          Union.create(
+            Union.create(Union.create(type1, type2, base, context), type3, base, context),
+            type4,
+            base,
+            context,
+          ),
           type5,
           base,
+          context,
         ),
         type6,
         base,
+        context,
       )
 
-    fun union(types: List<Type>, base: PklBaseModule): Type =
-      types.reduce { t1, t2 -> Union.create(t1, t2, base) }
+    fun union(types: List<Type>, base: PklBaseModule, context: PklProject?): Type =
+      types.reduce { t1, t2 -> Union.create(t1, t2, base, context) }
 
     fun function1(param1Type: Type, returnType: Type, base: PklBaseModule): Type =
       base.function1Type.withTypeArguments(param1Type, returnType)
@@ -95,33 +131,36 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
     allowClasses: Boolean,
     base: PklBaseModule,
     visitor: ResolveVisitor<*>,
+    context: PklProject?,
   ): Boolean
 
   abstract fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement>
 
   /** Tells whether this type is a (non-strict) subtype of [classType]. */
-  abstract fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean
+  abstract fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean
 
   /** Tells whether this type is a (non-strict) subtype of [type]. */
-  abstract fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean
+  abstract fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean
 
-  fun hasDefault(base: PklBaseModule) = if (isNullable(base)) true else hasDefaultImpl(base)
+  fun hasDefault(base: PklBaseModule, context: PklProject?) =
+    if (isNullable(base, context)) true else hasDefaultImpl(base, context)
 
-  protected abstract fun hasDefaultImpl(base: PklBaseModule): Boolean
+  protected abstract fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean
 
   /** Helper for implementing [isSubtypeOf]. */
-  protected fun doIsSubtypeOf(type: Type, base: PklBaseModule): Boolean =
+  protected fun doIsSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
     when (type) {
       Unknown -> true
-      is Class -> isSubtypeOf(type, base)
-      is Alias -> isSubtypeOf(type.aliasedType(base), base)
-      is Union -> isSubtypeOf(type.leftType, base) || isSubtypeOf(type.rightType, base)
+      is Class -> isSubtypeOf(type, base, context)
+      is Alias -> isSubtypeOf(type.aliasedType(base, context), base, context)
+      is Union ->
+        isSubtypeOf(type.leftType, base, context) || isSubtypeOf(type.rightType, base, context)
       else -> false
     }
 
   /** Note that `unknown` is equivalent to every type. */
-  fun isEquivalentTo(type: Type, base: PklBaseModule): Boolean =
-    isSubtypeOf(type, base) && type.isSubtypeOf(this, base)
+  fun isEquivalentTo(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
+    isSubtypeOf(type, base, context) && type.isSubtypeOf(this, base, context)
 
   /**
    * Tells if there is a refinement of this type that is a subtype of [type]. The trivial
@@ -131,14 +170,19 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
    * The motivation for this method is to check if `!isSubtypeOf(type)` could be caused by the type
    * system being too weak, which is only the case if `hasCommonSubtypeWith(type)`.
    */
-  abstract fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean
+  abstract fun hasCommonSubtypeWith(type: Type, base: PklBaseModule, context: PklProject?): Boolean
 
   /** Helper for implementing [hasCommonSubtypeWith]. */
-  protected fun doHasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
+  protected fun doHasCommonSubtypeWith(
+    type: Type,
+    base: PklBaseModule,
+    context: PklProject?,
+  ): Boolean =
     when (type) {
-      is Alias -> hasCommonSubtypeWith(type.aliasedType(base), base)
+      is Alias -> hasCommonSubtypeWith(type.aliasedType(base, context), base, context)
       is Union ->
-        hasCommonSubtypeWith(type.leftType, base) || hasCommonSubtypeWith(type.rightType, base)
+        hasCommonSubtypeWith(type.leftType, base, context) ||
+          hasCommonSubtypeWith(type.rightType, base, context)
       else -> true
     }
 
@@ -149,44 +193,48 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
    * Implementations should return `false` if there is a chance that the member is declared by a
    * subtype.
    */
-  abstract fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean
+  abstract fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean
 
-  open fun toClassType(base: PklBaseModule): Class? = null
+  open fun toClassType(base: PklBaseModule, context: PklProject?): Class? = null
 
-  open fun unaliased(base: PklBaseModule): Type? = this
+  open fun unaliased(base: PklBaseModule, context: PklProject?): Type? = this
 
-  open fun nonNull(base: PklBaseModule): Type = if (this == base.nullType) Nothing else this
+  open fun nonNull(base: PklBaseModule, context: PklProject?): Type =
+    if (this == base.nullType) Nothing else this
 
-  fun nullable(base: PklBaseModule): Type =
+  fun nullable(base: PklBaseModule, context: PklProject?): Type =
     // Foo? is syntactic sugar for Null|Foo
     // Null|Foo and Foo|Null are equivalent for typing purposes but have different defaults
-    union(base.nullType, this, base)
+    union(base.nullType, this, base, context)
 
   open val bindings: TypeParameterBindings = mapOf()
 
-  fun isNullable(base: PklBaseModule): Boolean = base.nullType.isSubtypeOf(this, base)
+  fun isNullable(base: PklBaseModule, context: PklProject?): Boolean =
+    base.nullType.isSubtypeOf(this, base, context)
 
-  fun isAmendable(base: PklBaseModule): Boolean = amended(base) != Nothing
+  fun isAmendable(base: PklBaseModule, context: PklProject?): Boolean =
+    amended(base, context) != Nothing
 
-  fun isInstantiable(base: PklBaseModule): Boolean = instantiated(base) != Nothing
+  fun isInstantiable(base: PklBaseModule, context: PklProject?): Boolean =
+    instantiated(base, context) != Nothing
 
   /**
    * The type of `expr {}` where `expr` has this type. Defaults to [Nothing], that is, not
    * amendable.
    */
-  open fun amended(base: PklBaseModule): Type = Nothing
+  open fun amended(base: PklBaseModule, context: PklProject?): Type = Nothing
 
   /**
    * The type of `new T {}` where `T` is this type. (Assumption: `T` is exactly the instantiated
    * type, not a supertype.) Defaults to [Nothing], that is, not instantiable.
    */
-  open fun instantiated(base: PklBaseModule): Type = amended(base)
+  open fun instantiated(base: PklBaseModule, context: PklProject?): Type = amended(base, context)
 
   /**
    * Type inside an amend block whose parent has this type. Leniently defaults to [Unknown] (instead
    * of [Nothing]) because "cannot amend type" is reported separately.
    */
-  open fun amending(base: PklBaseModule): Type = Unknown
+  open fun amending(base: PklBaseModule, context: PklProject?): Type = Unknown
 
   abstract fun render(builder: Appendable, nameRenderer: TypeNameRenderer = DefaultTypeNameRenderer)
 
@@ -194,12 +242,12 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
 
   override fun toString(): String = render()
 
-  fun getNode(project: Project): PklNode? =
+  fun getNode(project: Project, context: PklProject?): PklNode? =
     when (this) {
       is Class -> ctx
       is Module -> ctx
-      is StringLiteral -> project.pklBaseModule.stringType.getNode(project)
-      is Alias -> unaliased(project.pklBaseModule).getNode(project)
+      is StringLiteral -> project.pklBaseModule.stringType.getNode(project, context)
+      is Alias -> unaliased(project.pklBaseModule, context).getNode(project, context)
       is Union -> null
       else -> null
     }
@@ -210,18 +258,19 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean = true
 
     // Note: we aren't currently tracking constraints for unknown type (uncommon, would require a
     // class)
     override fun withConstraints(constraints: List<ConstraintExpr>): Type = this
 
-    override fun amended(base: PklBaseModule): Type =
+    override fun amended(base: PklBaseModule, context: PklProject?): Type =
       // Ideally we'd return "`unknown` with upper bound `base.amendedType`",
       // but this cannot currently be expressed
       Unknown
 
-    override fun amending(base: PklBaseModule): Type =
+    override fun amending(base: PklBaseModule, context: PklProject?): Type =
       // Ideally we'd return "`unknown` with upper bound `Object`",
       // but this cannot currently be expressed.
       Unknown
@@ -230,18 +279,23 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       builder.append("unknown")
     }
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean = true
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
+      true
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean = true
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean = true
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf()
 
     // `unknown` is not considered a valid answer
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean = false
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean = false
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = false
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean = false
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = false
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean = false
   }
 
   object Nothing : Type() {
@@ -250,6 +304,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean = true
 
     // constraints for bottom type aren't meaningful -> don't track them
@@ -257,16 +312,21 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf()
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean = true
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
+      true
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean = true
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean = true
 
     // `nothing` is not considered a valid answer
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean = false
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean = false
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = true
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean = true
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = false
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean = false
 
     override fun render(builder: Appendable, nameRenderer: TypeNameRenderer) {
       builder.append("nothing")
@@ -284,26 +344,31 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean = true
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf(ctx)
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean =
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
       classType.classEquals(base.anyType)
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
-      this == type || doIsSubtypeOf(type, base)
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
+      this == type || doIsSubtypeOf(type, base, context)
 
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
-      type.unaliased(base) != Nothing
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean = type.unaliased(base, context) != Nothing
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = true // treat like `Any`
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean =
+      true // treat like `Any`
 
-    override fun amended(base: PklBaseModule): Type = this
+    override fun amended(base: PklBaseModule, context: PklProject?): Type = this
 
-    override fun amending(base: PklBaseModule): Type = Unknown
+    override fun amending(base: PklBaseModule, context: PklProject?): Type = Unknown
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = false
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean = false
 
     override fun render(builder: Appendable, nameRenderer: TypeNameRenderer) {
       builder.append(ctx.name)
@@ -323,6 +388,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       internal fun create(
         ctx: PklModule,
         referenceName: String,
+        context: PklProject?,
         constraints: List<ConstraintExpr> = listOf(),
       ): Module {
         var result = ctx
@@ -331,7 +397,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         // if we can't resolve an amends reference, we bail out, i.e., invalid code may produce an
         // incorrect type.
         while (result.isAmend) {
-          result = result.supermodule ?: return Module(result, referenceName, constraints)
+          result = result.supermodule(context) ?: return Module(result, referenceName, constraints)
         }
         return Module(result, referenceName, constraints)
       }
@@ -345,52 +411,59 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean {
       return if (allowClasses) {
-        ctx.cache.visitTypeDefsAndPropertiesOrMethods(isProperty, visitor)
+        ctx.cache(context).visitTypeDefsAndPropertiesOrMethods(isProperty, visitor, context)
       } else {
-        ctx.cache.visitPropertiesOrMethods(isProperty, visitor)
+        ctx.cache(context).visitPropertiesOrMethods(isProperty, visitor, context)
       }
     }
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf(ctx)
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean =
-      base.moduleType.isSubtypeOf(classType, base)
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
+      base.moduleType.isSubtypeOf(classType, base, context)
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
       when (type) {
-        is Module -> isSubtypeOf(type)
-        else -> doIsSubtypeOf(type, base)
+        is Module -> isSubtypeOf(type, context)
+        else -> doIsSubtypeOf(type, base, context)
       }
 
-    private fun isSubtypeOf(type: Module): Boolean {
+    private fun isSubtypeOf(type: Module, context: PklProject?): Boolean {
       var currCtx: PklModule? = ctx
       while (currCtx != null) {
         // TODO: check if this actually works
         if (currCtx == type.ctx) return true
-        currCtx = currCtx.supermodule
+        currCtx = currCtx.supermodule(context)
       }
       return false
     }
 
-    fun supermodule(): Module? = ctx.supermodule?.let { module(it, it.shortDisplayName) }
+    fun supermodule(context: PklProject?): Module? =
+      ctx.supermodule(context)?.let { module(it, it.shortDisplayName, context) }
 
     // assumes `!this.isSubtypeOf(type)`
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean =
       when (type) {
-        is Module -> type.isSubtypeOf(this)
-        is Class -> type.isSubtypeOf(this, base)
-        else -> doHasCommonSubtypeWith(type, base)
+        is Module -> type.isSubtypeOf(this, context)
+        is Class -> type.isSubtypeOf(this, base, context)
+        else -> doHasCommonSubtypeWith(type, base, context)
       }
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = !ctx.isAbstractOrOpen
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean =
+      !ctx.isAbstractOrOpen
 
-    override fun amended(base: PklBaseModule): Type = this
+    override fun amended(base: PklBaseModule, context: PklProject?): Type = this
 
-    override fun amending(base: PklBaseModule): Type = this
+    override fun amending(base: PklBaseModule, context: PklProject?): Type = this
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = true
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean = true
 
     override fun render(builder: Appendable, nameRenderer: TypeNameRenderer) {
       nameRenderer.render(this, builder)
@@ -434,18 +507,19 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean {
-      ctx.cache.visitPropertiesOrMethods(isProperty, bindings, visitor)
+      ctx.cache(context).visitPropertiesOrMethods(isProperty, bindings, visitor, context)
       return true
     }
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf(ctx)
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean {
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean {
       // optimization
       if (classType.ctx === base.anyType.ctx) return true
 
-      if (!ctx.isSubclassOf(classType.ctx)) return false
+      if (!ctx.isSubclassOf(classType.ctx, context)) return false
 
       if (typeArguments.isEmpty()) {
         assert(classType.typeArguments.isEmpty()) // holds for stdlib
@@ -463,29 +537,34 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         val otherTypeArg = classType.typeArguments[otherSize - i]
         val isMatch =
           when (typeParam.variance) {
-            Variance.OUT -> typeArg.isSubtypeOf(otherTypeArg, base) // covariance
-            Variance.IN -> otherTypeArg.isSubtypeOf(typeArg, base) // contravariance
-            else -> typeArg.isEquivalentTo(otherTypeArg, base) // invariance
+            Variance.OUT -> typeArg.isSubtypeOf(otherTypeArg, base, context) // covariance
+            Variance.IN -> otherTypeArg.isSubtypeOf(typeArg, base, context) // contravariance
+            else -> typeArg.isEquivalentTo(otherTypeArg, base, context) // invariance
           }
         if (!isMatch) return false
       }
       return true
     }
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
       when (type) {
-        is Module -> ctx.isSubclassOf(type.ctx)
-        else -> doIsSubtypeOf(type, base)
+        is Module -> ctx.isSubclassOf(type.ctx, context)
+        else -> doIsSubtypeOf(type, base, context)
       }
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = !ctx.isAbstractOrOpen
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean =
+      !ctx.isAbstractOrOpen
 
     // assumes `!this.isSubtypeOf(type)`
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean =
       when (type) {
-        is Class -> hasCommonSubtypeWith(type, base)
-        is Module -> type.isSubtypeOf(this, base)
-        else -> doHasCommonSubtypeWith(type, base)
+        is Class -> hasCommonSubtypeWith(type, base, context)
+        is Module -> type.isSubtypeOf(this, base, context)
+        else -> doHasCommonSubtypeWith(type, base, context)
       }
 
     val isNullType: Boolean by lazy { ctx.name == "Null" && ctx.isInPklBaseModule }
@@ -505,26 +584,26 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         ctx.isInPklBaseModule
     }
 
-    override fun amended(base: PklBaseModule): Type =
+    override fun amended(base: PklBaseModule, context: PklProject?): Type =
       when {
-        classEquals(base.classType) -> typeArguments[0].amended(base)
+        classEquals(base.classType) -> typeArguments[0].amended(base, context)
         isFunctionType -> this
-        isSubtypeOf(base.objectType, base) -> this
+        isSubtypeOf(base.objectType, base, context) -> this
         else -> Nothing
       }
 
-    override fun instantiated(base: PklBaseModule): Type =
+    override fun instantiated(base: PklBaseModule, context: PklProject?): Type =
       when {
         ctx.isExternal -> Nothing
         ctx.isAbstract -> Nothing
         else -> this
       }
 
-    override fun amending(base: PklBaseModule): Type {
+    override fun amending(base: PklBaseModule, context: PklProject?): Type {
       return when {
-        isSubtypeOf(base.objectType, base) -> this
-        classEquals(base.classType) -> typeArguments[0].amending(base)
-        isFunctionType -> uncurriedResultType(base).amending(base)
+        isSubtypeOf(base.objectType, base, context) -> this
+        classEquals(base.classType) -> typeArguments[0].amending(base, context)
+        isFunctionType -> uncurriedResultType(base, context).amending(base, context)
         else -> {
           // Return `Unknown` instead of `Nothing` to avoid consecutive errors
           // inside an erroneous amend expression's object body.
@@ -535,15 +614,15 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       }
     }
 
-    override fun toClassType(base: PklBaseModule): Class = this
+    override fun toClassType(base: PklBaseModule, context: PklProject?): Class = this
 
     fun classEquals(other: Class): Boolean =
       // TODO: check if this works
       ctx == other.ctx
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean =
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean =
       when (base.objectType) {
-        is Class -> isSubtypeOf(base.objectType, base) && !ctx.isAbstract
+        is Class -> isSubtypeOf(base.objectType, base, context) && !ctx.isAbstract
         else -> false
       }
 
@@ -574,14 +653,14 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
     }
 
     // returns `C` given `(A) -> (B) -> C`
-    private fun uncurriedResultType(base: PklBaseModule): Type {
+    private fun uncurriedResultType(base: PklBaseModule, context: PklProject?): Type {
       assert(isFunctionType)
 
       var type = typeArguments.last()
-      var classType = type.toClassType(base)
+      var classType = type.toClassType(base, context)
       while (classType != null && classType.isFunctionType) {
         type = classType.typeArguments.last()
-        classType = type.toClassType(base)
+        classType = type.toClassType(base, context)
       }
       return type
     }
@@ -635,6 +714,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean {
       // return ctx.body.toType(base, bindings).visitMembers(isProperty, allowClasses, base,
       // visitor)
@@ -643,28 +723,33 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> = listOf(ctx)
 
-    fun aliasedType(base: PklBaseModule): Type = ctx.type.toType(base, bindings)
+    fun aliasedType(base: PklBaseModule, context: PklProject?): Type =
+      ctx.type.toType(base, bindings, context)
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean =
-      aliasedType(base).isSubtypeOf(classType, base)
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
+      aliasedType(base, context).isSubtypeOf(classType, base, context)
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
-      aliasedType(base).isSubtypeOf(type, base)
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
+      aliasedType(base, context).isSubtypeOf(type, base, context)
 
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
-      aliasedType(base).hasCommonSubtypeWith(type, base)
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean = aliasedType(base, context).hasCommonSubtypeWith(type, base, context)
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean =
-      aliasedType(base).isUnresolvedMemberFatal(base)
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean =
+      aliasedType(base, context).isUnresolvedMemberFatal(base, context)
 
-    override fun toClassType(base: PklBaseModule): Class? = unaliased(base) as? Class
+    override fun toClassType(base: PklBaseModule, context: PklProject?): Class? =
+      unaliased(base, context) as? Class
 
-    override fun nonNull(base: PklBaseModule): Type {
-      val aliasedType = aliasedType(base)
-      return if (aliasedType.isNullable(base)) aliasedType.nonNull(base) else this
+    override fun nonNull(base: PklBaseModule, context: PklProject?): Type {
+      val aliasedType = aliasedType(base, context)
+      return if (aliasedType.isNullable(base, context)) aliasedType.nonNull(base, context) else this
     }
 
-    override fun unaliased(base: PklBaseModule): Type {
+    override fun unaliased(base: PklBaseModule, context: PklProject?): Type {
       var type: Type = this
       // guard against (invalid) cyclic type alias definition
       val seen = IdentityHashMap<PklTypeAlias, PklTypeAlias>()
@@ -672,31 +757,32 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         val typeCtx = type.ctx
         // returning `type` here could cause infinite recursion in caller
         if (seen.put(typeCtx, typeCtx) != null) return Unknown
-        type = typeCtx.type.toType(base, type.bindings)
+        type = typeCtx.type.toType(base, type.bindings, context)
       }
       return type
     }
 
-    override fun amended(base: PklBaseModule): Type {
-      val aliased = aliasedType(base)
-      val amended = aliased.amended(base)
+    override fun amended(base: PklBaseModule, context: PklProject?): Type {
+      val aliased = aliasedType(base, context)
+      val amended = aliased.amended(base, context)
       return if (aliased == amended) this else amended // keep alias if possible
     }
 
-    override fun instantiated(base: PklBaseModule): Type {
+    override fun instantiated(base: PklBaseModule, context: PklProject?): Type {
       // special case: `Mixin` is instantiable even though `Function1` isn't
       // TODO: check if this works
       if (ctx == base.mixinType.ctx) return this
 
-      val aliased = aliasedType(base)
-      val instantiated = aliased.instantiated(base)
+      val aliased = aliasedType(base, context)
+      val instantiated = aliased.instantiated(base, context)
       return if (aliased == instantiated) this else instantiated // keep alias if possible
     }
 
-    override fun amending(base: PklBaseModule): Type = aliasedType(base).amending(base)
+    override fun amending(base: PklBaseModule, context: PklProject?): Type =
+      aliasedType(base, context).amending(base, context)
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean =
-      aliasedType(base).hasDefaultImpl(base)
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean =
+      aliasedType(base, context).hasDefaultImpl(base, context)
 
     @Suppress("Duplicates")
     override fun render(builder: Appendable, nameRenderer: TypeNameRenderer) {
@@ -723,29 +809,34 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean {
-      return base.stringType.visitMembers(isProperty, allowClasses, base, visitor)
+      return base.stringType.visitMembers(isProperty, allowClasses, base, visitor, context)
     }
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean {
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean {
       return classType.classEquals(base.stringType) || classType.classEquals(base.anyType)
     }
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
       when (type) {
         is StringLiteral -> value == type.value
-        else -> doIsSubtypeOf(type, base)
+        else -> doIsSubtypeOf(type, base, context)
       }
 
     // assumes `!isSubtypeOf(type)`
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean = false
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean = false
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean = true
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean = true
 
     override fun resolveToDefinitions(base: PklBaseModule): List<PklNavigableElement> =
       listOf(base.stringType.ctx)
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = true
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean = true
 
     override fun render(builder: Appendable, nameRenderer: TypeNameRenderer) = render(builder, "\"")
 
@@ -763,7 +854,12 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
     Type(constraints) {
     companion object {
       // this method exists because `Type.union(t1, t2)` can't see the private constructor
-      internal fun create(leftType: Type, rightType: Type, base: PklBaseModule): Type {
+      internal fun create(
+        leftType: Type,
+        rightType: Type,
+        base: PklBaseModule,
+        context: PklProject?,
+      ): Type {
         val atMostOneTypeHasConstraints = !leftType.hasConstraints || !rightType.hasConstraints
         return when {
           // Only normalize if we don't lose relevant constraints in the process.
@@ -772,13 +868,13 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
           // Also don't normalize `String|"stringLiteral"` because we need the string literal type
           // for code completion.
           atMostOneTypeHasConstraints &&
-            leftType.isSubtypeOf(rightType, base) &&
-            rightType.unaliased(base) != base.stringType -> {
+            leftType.isSubtypeOf(rightType, base, context) &&
+            rightType.unaliased(base, context) != base.stringType -> {
             rightType
           }
           atMostOneTypeHasConstraints &&
-            rightType.isSubtypeOf(leftType, base) &&
-            leftType.unaliased(base) != base.stringType -> {
+            rightType.isSubtypeOf(leftType, base, context) &&
+            leftType.unaliased(base, context) != base.stringType -> {
             leftType
           }
           else -> Union(leftType, rightType, listOf())
@@ -794,40 +890,47 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
       allowClasses: Boolean,
       base: PklBaseModule,
       visitor: ResolveVisitor<*>,
+      context: PklProject?,
     ): Boolean {
       if (isUnionOfStringLiterals) {
         // visit pkl.base#String once rather than for every string literal
         // (unions of 70+ string literals have been seen in the wild)
-        return base.stringType.visitMembers(isProperty, allowClasses, base, visitor)
+        return base.stringType.visitMembers(isProperty, allowClasses, base, visitor, context)
       }
 
-      return leftType.visitMembers(isProperty, allowClasses, base, visitor) &&
-        rightType.visitMembers(isProperty, allowClasses, base, visitor)
+      return leftType.visitMembers(isProperty, allowClasses, base, visitor, context) &&
+        rightType.visitMembers(isProperty, allowClasses, base, visitor, context)
     }
 
-    override fun isSubtypeOf(classType: Class, base: PklBaseModule): Boolean =
-      leftType.isSubtypeOf(classType, base) && rightType.isSubtypeOf(classType, base)
+    override fun isSubtypeOf(classType: Class, base: PklBaseModule, context: PklProject?): Boolean =
+      leftType.isSubtypeOf(classType, base, context) &&
+        rightType.isSubtypeOf(classType, base, context)
 
-    override fun isSubtypeOf(type: Type, base: PklBaseModule): Boolean =
-      leftType.isSubtypeOf(type, base) && rightType.isSubtypeOf(type, base)
+    override fun isSubtypeOf(type: Type, base: PklBaseModule, context: PklProject?): Boolean =
+      leftType.isSubtypeOf(type, base, context) && rightType.isSubtypeOf(type, base, context)
 
     // assumes `!this.isSubtypeOf(type)`
-    override fun hasCommonSubtypeWith(type: Type, base: PklBaseModule): Boolean =
-      leftType.isSubtypeOf(type, base) ||
-        leftType.hasCommonSubtypeWith(type, base) ||
-        rightType.isSubtypeOf(type, base) ||
-        rightType.hasCommonSubtypeWith(type, base)
+    override fun hasCommonSubtypeWith(
+      type: Type,
+      base: PklBaseModule,
+      context: PklProject?,
+    ): Boolean =
+      leftType.isSubtypeOf(type, base, context) ||
+        leftType.hasCommonSubtypeWith(type, base, context) ||
+        rightType.isSubtypeOf(type, base, context) ||
+        rightType.hasCommonSubtypeWith(type, base, context)
 
-    override fun isUnresolvedMemberFatal(base: PklBaseModule): Boolean =
-      leftType.isUnresolvedMemberFatal(base) && rightType.isUnresolvedMemberFatal(base)
+    override fun isUnresolvedMemberFatal(base: PklBaseModule, context: PklProject?): Boolean =
+      leftType.isUnresolvedMemberFatal(base, context) &&
+        rightType.isUnresolvedMemberFatal(base, context)
 
-    override fun toClassType(base: PklBaseModule): Class? =
+    override fun toClassType(base: PklBaseModule, context: PklProject?): Class? =
       if (leftType.hasConstraints && rightType.hasConstraints) {
         // Ensure that `toClassType(CT(c1)|CT(c2)|CT(c3))`,
         // whose argument isn't normalized due to different constraints,
         // returns `CT`.
-        leftType.toClassType(base)?.let { leftClassType ->
-          rightType.toClassType(base)?.let { rightClassType ->
+        leftType.toClassType(base, context)?.let { leftClassType ->
+          rightType.toClassType(base, context)?.let { rightClassType ->
             if (leftClassType.classEquals(rightClassType)) leftClassType else null
           }
         }
@@ -839,28 +942,35 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         else -> leftType.resolveToDefinitions(base) + rightType.resolveToDefinitions(base)
       }
 
-    override fun nonNull(base: PklBaseModule): Type =
+    override fun nonNull(base: PklBaseModule, context: PklProject?): Type =
       when {
-        leftType == base.nullType -> rightType.nonNull(base)
-        rightType == base.nullType -> leftType.nonNull(base)
+        leftType == base.nullType -> rightType.nonNull(base, context)
+        rightType == base.nullType -> leftType.nonNull(base, context)
         else ->
-          create(leftType.nonNull(base), rightType.nonNull(base), base).withConstraints(constraints)
+          create(leftType.nonNull(base, context), rightType.nonNull(base, context), base, context)
+            .withConstraints(constraints)
       }
 
-    override fun amended(base: PklBaseModule): Type =
-      create(leftType.amended(base), rightType.amended(base), base).withConstraints(constraints)
+    override fun amended(base: PklBaseModule, context: PklProject?): Type =
+      create(leftType.amended(base, context), rightType.amended(base, context), base, context)
+        .withConstraints(constraints)
 
-    override fun instantiated(base: PklBaseModule): Type =
-      create(leftType.instantiated(base), rightType.instantiated(base), base)
+    override fun instantiated(base: PklBaseModule, context: PklProject?): Type =
+      create(
+        leftType.instantiated(base, context),
+        rightType.instantiated(base, context),
+        base,
+        context,
+      )
 
-    override fun amending(base: PklBaseModule): Type =
+    override fun amending(base: PklBaseModule, context: PklProject?): Type =
       when {
         // assume this type is amendable (checked separately)
         // and remove alternatives that can't
-        !leftType.isAmendable(base) -> rightType.amending(base)
-        !rightType.isAmendable(base) -> leftType.amending(base)
+        !leftType.isAmendable(base, context) -> rightType.amending(base, context)
+        !rightType.isAmendable(base, context) -> leftType.amending(base, context)
         else ->
-          create(leftType.amending(base), rightType.amending(base), base)
+          create(leftType.amending(base, context), rightType.amending(base, context), base, context)
             .withConstraints(constraints)
       }
 
@@ -884,7 +994,8 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
         (rightType is StringLiteral || rightType is Union && rightType.isUnionOfStringLiterals)
     }
 
-    override fun hasDefaultImpl(base: PklBaseModule): Boolean = leftType.hasDefaultImpl(base)
+    override fun hasDefaultImpl(base: PklBaseModule, context: PklProject?): Boolean =
+      leftType.hasDefaultImpl(base, context)
   }
 }
 
@@ -893,22 +1004,30 @@ typealias TypeParameterBindings = Map<PklTypeParameter, Type>
 fun PklType?.toType(
   base: PklBaseModule,
   bindings: Map<PklTypeParameter, Type>,
+  context: PklProject?,
   preserveUnboundTypeVars: Boolean = false,
 ): Type =
   when (this) {
     null -> Type.Unknown
     is PklDeclaredType -> {
       val simpleName = name.simpleTypeName
-      when (val resolved = simpleName.resolve()) {
+      when (val resolved = simpleName.resolve(context)) {
         null -> Type.Unknown
-        is PklModule -> Type.module(resolved, simpleName.identifier!!.text)
+        is PklModule -> Type.module(resolved, simpleName.identifier!!.text, context)
         is PklClass -> {
           val typeArguments = this.typeArgumentList?.types ?: listOf()
-          Type.Class(resolved, typeArguments.toTypes(base, bindings, preserveUnboundTypeVars))
+          Type.Class(
+            resolved,
+            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars),
+          )
         }
         is PklTypeAlias -> {
           val typeArguments = this.typeArgumentList?.types ?: listOf()
-          Type.alias(resolved, typeArguments.toTypes(base, bindings, preserveUnboundTypeVars))
+          Type.alias(
+            resolved,
+            context,
+            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars),
+          )
         }
         is PklTypeParameter ->
           bindings[resolved]
@@ -918,13 +1037,14 @@ fun PklType?.toType(
     }
     is PklUnionType ->
       Type.union(
-        leftType.toType(base, bindings, preserveUnboundTypeVars),
-        rightType.toType(base, bindings, preserveUnboundTypeVars),
+        leftType.toType(base, bindings, context, preserveUnboundTypeVars),
+        rightType.toType(base, bindings, context, preserveUnboundTypeVars),
         base,
+        context,
       )
     is PklFunctionType -> {
-      val parameterTypes = parameterList.toTypes(base, bindings, preserveUnboundTypeVars)
-      val returnType = returnType.toType(base, bindings, preserveUnboundTypeVars)
+      val parameterTypes = parameterList.toTypes(base, bindings, context, preserveUnboundTypeVars)
+      val returnType = returnType.toType(base, bindings, context, preserveUnboundTypeVars)
       when (parameterTypes.size) {
         0 -> base.function0Type.withTypeArguments(parameterTypes + returnType)
         1 -> base.function1Type.withTypeArguments(parameterTypes + returnType)
@@ -938,19 +1058,20 @@ fun PklType?.toType(
           ) // approximation (invalid Pkl code)
       }
     }
-    is PklParenthesizedType -> type.toType(base, bindings, preserveUnboundTypeVars)
-    is PklDefaultUnionType -> type.toType(base, bindings, preserveUnboundTypeVars)
+    is PklParenthesizedType -> type.toType(base, bindings, context, preserveUnboundTypeVars)
+    is PklDefaultUnionType -> type.toType(base, bindings, context, preserveUnboundTypeVars)
     is PklConstrainedType -> {
       // TODO: cache `constraintExprs`
-      val constraintExprs = exprs.toConstraintExprs(project.pklBaseModule)
-      type.toType(base, bindings, preserveUnboundTypeVars).withConstraints(constraintExprs)
+      val constraintExprs = exprs.toConstraintExprs(project.pklBaseModule, context)
+      type.toType(base, bindings, context, preserveUnboundTypeVars).withConstraints(constraintExprs)
     }
-    is PklNullableType -> type.toType(base, bindings, preserveUnboundTypeVars).nullable(base)
+    is PklNullableType ->
+      type.toType(base, bindings, context, preserveUnboundTypeVars).nullable(base, context)
     is PklUnknownType -> Type.Unknown
     is PklNothingType -> Type.Nothing
     is PklModuleType -> {
       // TODO: for `open` modules, `module` is a self-type
-      enclosingModule?.let { Type.module(it, "module") } ?: base.moduleType
+      enclosingModule?.let { Type.module(it, "module", context) } ?: base.moduleType
     }
     is PklStringLiteralType ->
       stringConstant.escapedText()?.let { Type.StringLiteral(it) } ?: Type.Unknown
@@ -961,5 +1082,6 @@ fun PklType?.toType(
 fun List<PklType>.toTypes(
   base: PklBaseModule,
   bindings: Map<PklTypeParameter, Type>,
+  context: PklProject?,
   preserveTypeVariables: Boolean = false,
-): List<Type> = map { it.toType(base, bindings, preserveTypeVariables) }
+): List<Type> = map { it.toType(base, bindings, context, preserveTypeVariables) }

--- a/src/main/kotlin/org/pkl/lsp/util/CachedValuesManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/CachedValuesManager.kt
@@ -24,7 +24,7 @@ data class CachedValue<T>(val value: T, val dependencies: List<ModificationTrack
 }
 
 class CachedValuesManager(project: Project) : Component(project) {
-  private val cachedValues: MutableMap<String, Pair<List<Int>, CachedValue<*>>> =
+  private val cachedValues: MutableMap<String, Pair<List<Long>, CachedValue<*>>> =
     ConcurrentHashMap()
 
   /** Returns the currently cached value, or `null` if the cached value is out of date. */
@@ -41,7 +41,7 @@ class CachedValuesManager(project: Project) : Component(project) {
     cachedValues[key] = value.dependencies.map { it.getModificationCount() } to value
   }
 
-  private fun CachedValue<*>.isUpToDate(lastModificationCounts: List<Int>): Boolean {
+  private fun CachedValue<*>.isUpToDate(lastModificationCounts: List<Long>): Boolean {
     if (lastModificationCounts.size != dependencies.size) {
       throw IllegalArgumentException("Modification counts do not match dependency size")
     }

--- a/src/main/kotlin/org/pkl/lsp/util/FileCacheManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/FileCacheManager.kt
@@ -30,8 +30,7 @@ import org.pkl.lsp.ast.PklModule
 class FileCacheManager(project: Project) : Component(project) {
   companion object {
     private val pklHomeDir: Path = Path.of(System.getProperty("user.home")).resolve(".pkl")
-    val pklCacheDir: Path? =
-      pklHomeDir.resolve("cache").let { if (Files.isDirectory(it)) it else null }
+    val pklCacheDir: Path = pklHomeDir.resolve("cache")
   }
 
   val lspCacheDir: Path by lazy { Files.createTempDirectory("pkl-lsp-cache") }

--- a/src/main/kotlin/org/pkl/lsp/util/URISerializer.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/URISerializer.kt
@@ -15,18 +15,22 @@
  */
 package org.pkl.lsp.util
 
-import java.util.concurrent.atomic.AtomicLong
+import java.net.URI
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
 
-interface ModificationTracker {
-  fun getModificationCount(): Long
-}
+object URISerializer : KSerializer<URI> {
+  override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("URI", PrimitiveKind.STRING)
 
-class SimpleModificationTracker : ModificationTracker {
-  private val count = AtomicLong(0)
+  override fun deserialize(decoder: Decoder): URI {
+    return URI(decoder.decodeString())
+  }
 
-  override fun getModificationCount(): Long = count.get()
-
-  fun increment() {
-    count.incrementAndGet()
+  override fun serialize(encoder: Encoder, value: URI) {
+    return encoder.encodeString(value.toString())
   }
 }

--- a/src/main/resources/org/pkl/lsp/errorMessages.properties
+++ b/src/main/resources/org/pkl/lsp/errorMessages.properties
@@ -111,3 +111,15 @@ Package imports must contain a fragment that starts with `/`.
 
 missingPackageSources=\
 Missing sources for package `{0}`.
+
+cannotFindDependency=\
+Cannot find dependency `{0}`.
+
+pklProjectFileModified=\
+A PklProject file was modified.
+
+unsyncedPklProject=\
+Project is out of sync.
+
+pklCliNotConfigured=\
+Pkl CLI is not configured.

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test
 import org.pkl.lsp.ast.PklClassProperty
 import org.pkl.lsp.ast.PklModuleHeader
 import org.pkl.lsp.packages.dto.PackageUri
+import org.pkl.lsp.util.FileCacheManager.Companion.pklCacheDir
 
 class GoToDefinitionPackagesTest : LSPTestBase() {
   companion object {
@@ -35,6 +36,7 @@ class GoToDefinitionPackagesTest : LSPTestBase() {
               "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2"
             )!!
           ),
+          pklCacheDir,
           false,
         )
         .get()

--- a/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
@@ -16,12 +16,16 @@
 package org.pkl.lsp
 
 import java.net.URI
+import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.io.path.toPath
 import kotlin.io.path.writeText
 import org.eclipse.lsp4j.*
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.io.TempDir
 import org.pkl.core.parser.Parser
 import org.pkl.lsp.ast.PklModule
@@ -40,7 +44,7 @@ abstract class LSPTestBase {
     fun beforeAll() {
       server = PklLSPServer(true).also { it.connect(TestLanguageClient) }
       parser = Parser()
-      fakeProject = Project(server)
+      fakeProject = server.project
       System.getProperty("pklExecutable")?.let {
         fakeProject.settingsManager.settings.pklCliPath = Path.of(it)
       }
@@ -55,9 +59,29 @@ abstract class LSPTestBase {
 
   private val modules: MutableMap<URI, PklModule> = HashMap()
 
-  protected fun createPklFile(contents: String) {
-    createPklFile("main.pkl", contents)
+  @BeforeEach
+  open fun beforeEach() {
+    server.initialize(
+      InitializeParams().apply {
+        capabilities =
+          ClientCapabilities().apply {
+            workspace = WorkspaceClientCapabilities().apply { workspaceFolders = true }
+          }
+        workspaceFolders =
+          listOf(WorkspaceFolder(testProjectDir.toUri().toString(), testProjectDir.name))
+      }
+    )
+    server.initialized(InitializedParams())
+    TestLanguageClient.testProjectDir = testProjectDir
+    TestLanguageClient.reset()
   }
+
+  @AfterEach
+  open fun afterEach() {
+    server.shutdown()
+  }
+
+  protected fun createPklFile(contents: String): Path = createPklFile("main.pkl", contents)
 
   /**
    * Creates a Pkl file with [contents] in the test project, and also sets the currently active
@@ -68,7 +92,7 @@ abstract class LSPTestBase {
    *
    * If this method is called multiple times, the last call determines the active editor.
    */
-  protected fun createPklFile(name: String, contents: String) {
+  protected fun createPklFile(name: String, contents: String): Path {
     val caret = contents.indexOf("<caret>")
     val effectiveContents =
       if (caret == -1) contents else contents.replaceRange(caret, caret + 7, "")
@@ -82,6 +106,7 @@ abstract class LSPTestBase {
       caretPosition = getPosition(effectiveContents, caret)
     }
     fileInFocus = file
+    return file
   }
 
   /**
@@ -108,6 +133,35 @@ abstract class LSPTestBase {
     }
   }
 
+  protected fun typeText(text: String) {
+    if (fileInFocus == null) {
+      throw IllegalStateException(
+        "No active Pkl module found in editor. Call `createPklFile` first."
+      )
+    }
+    val currentText = fileInFocus!!.readText()
+    val idx = caretPosition?.let { getIndex(currentText, it) } ?: (currentText.length - 1)
+    val newText = currentText.replaceRange(idx..idx, text)
+    Files.writeString(fileInFocus, newText)
+    server.textDocumentService.didChange(
+      DidChangeTextDocumentParams(
+        VersionedTextDocumentIdentifier(fileInFocus!!.toUri().toString(), 0),
+        listOf(TextDocumentContentChangeEvent(newText)),
+      )
+    )
+  }
+
+  protected fun saveFile() {
+    if (fileInFocus == null) {
+      throw IllegalStateException(
+        "No active Pkl module found in editor. Call `createPklFile` first."
+      )
+    }
+    server.textDocumentService.didSave(
+      DidSaveTextDocumentParams(TextDocumentIdentifier(fileInFocus!!.toUri().toString()))
+    )
+  }
+
   private fun getOrInsertModule(uri: URI): PklModule {
     modules[uri]?.let {
       return it
@@ -128,21 +182,17 @@ abstract class LSPTestBase {
 
   private fun resolveToRealUri(uri: String): URI =
     if (uri.startsWith("file:/") && !uri.startsWith("file:///")) Path.of(URI(uri)).toUri()
-    else VirtualFile.fromUri(URI(uri), fakeProject)!!.uri
+    else fakeProject.virtualFileManager.get(URI(uri))!!.uri
 
   private fun parseAndStoreModule(contents: String, path: Path): PklModule {
     val moduleCtx = parser.parseModule(contents)
-    return PklModuleImpl(moduleCtx, path.toUri(), FsFile(path, fakeProject)).also {
-      modules[path.toUri()] = it
-    }
+    return PklModuleImpl(moduleCtx, FsFile(path, fakeProject)).also { modules[path.toUri()] = it }
   }
 
   private fun parseAndStoreJar(contents: String, path: Path): PklModule {
     val moduleCtx = parser.parseModule(contents)
     val uri = path.toUri()
-    return PklModuleImpl(moduleCtx, path.toUri(), JarFile(path, uri, fakeProject)).also {
-      modules[uri] = it
-    }
+    return PklModuleImpl(moduleCtx, JarFile(path, uri, fakeProject)).also { modules[uri] = it }
   }
 
   private fun Path.toTextDocument(effectiveContents: String): TextDocumentItem =
@@ -159,5 +209,16 @@ abstract class LSPTestBase {
       currentPos = nextPos
     }
     throw IllegalArgumentException("Invalid index for contents")
+  }
+
+  private fun getIndex(contents: String, position: Position): Int {
+    var currentIndex = 0
+    for ((column, line) in contents.lines().withIndex()) {
+      if (column == position.line) {
+        return currentIndex + position.character
+      }
+      currentIndex += line.length + 1 // + 1 because newline is also a character
+    }
+    throw IllegalArgumentException("Invalid position for contents")
   }
 }

--- a/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LSPTestBase.kt
@@ -45,8 +45,9 @@ abstract class LSPTestBase {
       server = PklLSPServer(true).also { it.connect(TestLanguageClient) }
       parser = Parser()
       fakeProject = server.project
-      System.getProperty("pklExecutable")?.let {
-        fakeProject.settingsManager.settings.pklCliPath = Path.of(it)
+      System.getProperty("pklExecutable")?.let { executablePath ->
+        TestLanguageClient.settings["Pkl" to "pkl.cli.path"] = executablePath
+        fakeProject.settingsManager.settings.pklCliPath = Path.of(executablePath)
       }
     }
   }
@@ -74,6 +75,7 @@ abstract class LSPTestBase {
     server.initialized(InitializedParams())
     TestLanguageClient.testProjectDir = testProjectDir
     TestLanguageClient.reset()
+    fakeProject.initialize().get()
   }
 
   @AfterEach

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -17,7 +17,6 @@ package org.pkl.lsp
 
 import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -44,12 +43,7 @@ class SyncProjectsTest : LSPTestBase() {
     """
           .trimIndent(),
       )
-    fakeProject.pklProjectManager.syncProjects().get()
-  }
-
-  @AfterEach
-  override fun afterEach() {
-    super.afterEach()
+    fakeProject.pklProjectManager.syncProjects(false).get()
   }
 
   @Test

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -1,0 +1,113 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import java.nio.file.Path
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.pkl.lsp.services.PklWorkspaceState
+
+class SyncProjectsTest : LSPTestBase() {
+
+  private lateinit var projectFile: Path
+
+  @BeforeEach
+  override fun beforeEach() {
+    super.beforeEach()
+    projectFile =
+      createPklFile(
+        "PklProject",
+        """
+      amends "pkl:Project"
+      
+      dependencies {
+        ["appEnvCluster"] {
+          uri = "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2"
+        }
+      }
+    """
+          .trimIndent(),
+      )
+    fakeProject.pklProjectManager.syncProjects().get()
+  }
+
+  @AfterEach
+  override fun afterEach() {
+    super.afterEach()
+  }
+
+  @Test
+  fun `resolves dependencies`() {
+    val vfile = fakeProject.virtualFileManager.get(projectFile)
+    assertThat(vfile).isNotNull
+    vfile!!
+    val pklProject = fakeProject.pklProjectManager.getPklProject(vfile)
+    assertThat(pklProject).isNotNull
+    pklProject!!
+    assertThat(pklProject.projectDeps!!.resolvedDependencies)
+      .containsOnlyKeys(
+        "package://pkg.pkl-lang.org/pkl-k8s/k8s@1",
+        "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1",
+      )
+    assertThat(pklProject.myDependencies).containsOnlyKeys("appEnvCluster")
+  }
+
+  @Test
+  fun `syncing projects persists state`() {
+    val pklLspDir = testProjectDir.resolve(".pkl-lsp")
+    assertThat(pklLspDir).isDirectory()
+    val projectsJsonFile = pklLspDir.resolve("projects.json")
+    assertThat(projectsJsonFile).exists()
+    val state = PklWorkspaceState.load(pklLspDir.resolve("projects.json"))
+    assertThat(state.pklProjects).hasSize(1)
+    val project = state.pklProjects.first()
+    assertThat(project.projectFile).isEqualTo("PklProject")
+    assertThat(project.resolvedDependencies)
+      .containsOnlyKeys(
+        "package://pkg.pkl-lang.org/pkl-k8s/k8s@1",
+        "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1",
+      )
+    assertThat(project.declaredDependencies).containsOnlyKeys("appEnvCluster")
+  }
+
+  @Test
+  @Disabled("For some reason this test only works in isolation")
+  fun `changing a PklProject file causes a sync project notification message to appear`() {
+    typeText("\n\n")
+    saveFile()
+    assertThat(TestLanguageClient.actionableNotifications).hasSize(1)
+    assertThat(TestLanguageClient.actionableNotifications.first().commands).hasSize(1)
+    assertThat(TestLanguageClient.actionableNotifications.first().commands.first().command)
+      .isEqualTo("pkl.syncProjects")
+  }
+
+  @Test
+  fun `resolve remote dependency`() {
+    createPklFile(
+      """
+      import "@appEnvCluster/AppEnvCluster.pkl<caret>"
+    """
+        .trimIndent()
+    )
+    val resolved = goToDefinition()
+    assertThat(resolved).hasSize(1)
+    val resolvedFile = resolved.first().containingFile
+    assertThat(resolvedFile).isInstanceOf(JarFile::class.java)
+  }
+}

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -43,7 +43,13 @@ class SyncProjectsTest : LSPTestBase() {
     """
           .trimIndent(),
       )
-    fakeProject.pklProjectManager.syncProjects(false).get()
+    fakeProject.pklProjectManager
+      .syncProjects(
+        // prevent other components from reacting to this change because these file gets deleted
+        // after each test finishes
+        emitEvents = false
+      )
+      .get()
   }
 
   @Test

--- a/src/test/kotlin/org/pkl/lsp/TestLanguageClient.kt
+++ b/src/test/kotlin/org/pkl/lsp/TestLanguageClient.kt
@@ -15,14 +15,25 @@
  */
 package org.pkl.lsp
 
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
-import org.eclipse.lsp4j.MessageActionItem
-import org.eclipse.lsp4j.MessageParams
-import org.eclipse.lsp4j.PublishDiagnosticsParams
-import org.eclipse.lsp4j.ShowMessageRequestParams
-import org.eclipse.lsp4j.services.LanguageClient
+import kotlin.io.path.name
+import org.eclipse.lsp4j.*
+import org.pkl.lsp.messages.ActionableNotification
 
-object TestLanguageClient : LanguageClient {
+object TestLanguageClient : PklLanguageClient {
+  lateinit var testProjectDir: Path
+
+  val actionableNotifications: MutableList<ActionableNotification> = mutableListOf()
+
+  fun reset() {
+    actionableNotifications.clear()
+  }
+
+  override fun sendActionableNotification(params: ActionableNotification) {
+    actionableNotifications.add(params)
+  }
+
   override fun telemetryEvent(`object`: Any?) {
     // no-op
   }
@@ -44,5 +55,17 @@ object TestLanguageClient : LanguageClient {
 
   override fun logMessage(message: MessageParams?) {
     // no-op
+  }
+
+  override fun workspaceFolders(): CompletableFuture<List<WorkspaceFolder>> {
+    return CompletableFuture.completedFuture(
+      listOf(WorkspaceFolder(testProjectDir.toUri().toString(), testProjectDir.name))
+    )
+  }
+
+  override fun configuration(
+    configurationParams: ConfigurationParams
+  ): CompletableFuture<List<Any>> {
+    return CompletableFuture.completedFuture(listOf())
   }
 }

--- a/src/test/kotlin/org/pkl/lsp/TestLanguageClient.kt
+++ b/src/test/kotlin/org/pkl/lsp/TestLanguageClient.kt
@@ -53,8 +53,16 @@ object TestLanguageClient : PklLanguageClient {
     return CompletableFuture()
   }
 
-  override fun logMessage(message: MessageParams?) {
-    // no-op
+  override fun logMessage(message: MessageParams) {
+    @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
+    val label =
+      when (message.type) {
+        MessageType.Info -> "INFO"
+        MessageType.Log -> "LOG"
+        MessageType.Warning -> "WARNING"
+        MessageType.Error -> "ERROR"
+      }
+    println("[$label] ${message.message}")
   }
 
   override fun workspaceFolders(): CompletableFuture<List<WorkspaceFolder>> {


### PR DESCRIPTION
This adds support for projects, and also adds various flows needed for project support.

* Make VirtualFile conform to ModificationTracker, and introduce VirtualFileManager to track changes
* Introduce messaging API to propagate information between components, so each component can handle its own logic without interweaving dependencies
* Introduce PklProjectManager, and data classes to model pkl projects. This component manages PklProject state, and persists it to `.pkl-lsp/projects.json`.
* Change resolvers to use PklProject context to look for details
* Introduce new ActionableNotification notification request, used to display messages with calls to action in the client
* Add "Sync Project" and "Configure Pkl CLI" flows
* Add logic to detect if PklProject files have been modified and project needs to be re-synced
* Introduce lifecycle events for Component (initialize, dispose) and managed by Project
* Move field `package` from `PklModule` to `VirtualFile`, to be consistent with where `pklProjectDir` is
* Change custom virtual file scheme from `pkl` to `pkl-lsp` in order to avoid conflict with stdlib scheme (needed by VirtualFileManager)