### PR TITLE
Make LSP configurable using initialization options

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ClientCapabilities.kt
+++ b/src/main/kotlin/org/pkl/lsp/ClientCapabilities.kt
@@ -1,0 +1,34 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import org.eclipse.lsp4j.ClientCapabilities
+
+data class PklClientCapabilities(
+  /** Default capabilities as defined by the LSP spec. */
+  val standard: ClientCapabilities,
+
+  /** Additional capabilites defined by the Pkl LSP. */
+  val extended: ExtendedClientCapabilities,
+)
+
+data class ExtendedClientCapabilities(
+  /** This client supports the `"pkl/actionableNotification"` message. */
+  val actionableRuntimeNotifications: Boolean? = null,
+
+  /** This client supports the `"pkl.configure"` command. */
+  val pklConfigureCommand: Boolean? = null,
+)

--- a/src/main/kotlin/org/pkl/lsp/LSPUtil.kt
+++ b/src/main/kotlin/org/pkl/lsp/LSPUtil.kt
@@ -118,8 +118,9 @@ fun parseUriOrNull(uriStr: String): URI? =
 
 val osName: String by lazy { System.getProperty("os.name") }
 
-fun Path.toUnixPathString() =
-  if (osName.contains("Windows")) toString().replace("\\", "/") else toString()
+val isWindows: Boolean by lazy { osName.contains("Windows") }
+
+fun Path.toUnixPathString() = if (isWindows) toString().replace("\\", "/") else toString()
 
 val URI.effectiveUri: URI?
   get() {

--- a/src/main/kotlin/org/pkl/lsp/PklClientOptions.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklClientOptions.kt
@@ -1,0 +1,31 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+/** Additional options passed by a language client when initializing the LSP. */
+data class PklClientOptions(
+  /**
+   * Cause documentation to render URIs in the form of `command:pkl.open.file?[URI,line,column]`.
+   */
+  val renderOpenFileCommandInDocs: Boolean = false,
+
+  /** Additional capabilities supported by this client. */
+  val extendedClientCapabilities: ExtendedClientCapabilities = ExtendedClientCapabilities(),
+) {
+  companion object {
+    val default = PklClientOptions()
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/Project.kt
+++ b/src/main/kotlin/org/pkl/lsp/Project.kt
@@ -48,6 +48,10 @@ class Project(private val server: PklLSPServer) {
 
   val diagnosticsManager: DiagnosticsManager by lazy { DiagnosticsManager(this) }
 
+  val clientOptions: PklClientOptions by lazy { server.pklClientOptions }
+
+  val clientCapabilities: PklClientCapabilities by lazy { server.clientCapabilities }
+
   fun initialize(): CompletableFuture<*> {
     return CompletableFuture.allOf(*myComponents.map { it.initialize() }.toTypedArray())
   }

--- a/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
@@ -23,7 +23,6 @@ import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.pkl.lsp.Component
-import org.pkl.lsp.LSPUtil.toRange
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.packages.dto.PklProject
@@ -72,10 +71,10 @@ class GoToDefinitionFeature(project: Project) : Component(project) {
     val stringContentsSpan = originalNode.contentsSpan()
     if (parent is PklImportBase && parent.isGlob) {
       val resolved = parent.moduleUri?.resolveGlob(context) ?: return listOf()
-      return resolved.map { it.toLocationLink(stringContentsSpan) }
+      return resolved.map { it.locationLink(stringContentsSpan) }
     }
     val resolved = parent.moduleUri?.resolve(context) ?: return listOf()
-    return listOf(resolved.toLocationLink(stringContentsSpan))
+    return listOf(resolved.locationLink(stringContentsSpan))
   }
 
   private fun resolveDeclarations(
@@ -101,10 +100,5 @@ class GoToDefinitionFeature(project: Project) : Component(project) {
         else -> if (node !== originalNode) listOf(node.location) else emptyList()
       }
     return Either.forLeft(ret)
-  }
-
-  private fun PklNode.toLocationLink(originalSpan: Span): LocationLink {
-    val range = beginningSpan().toRange()
-    return LocationLink(toLspURIString(), range, range, originalSpan.toRange())
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/HoverFeature.kt
@@ -288,7 +288,7 @@ class HoverFeature(project: Project) : Component(project) {
     val module = (if (node is PklModule) node else node?.enclosingModule)
     val footer =
       if (module != null) {
-        "\n\n---\n\nin [${module.moduleName}](${module.toCommandURIString()})"
+        "\n\n---\n\nin [${module.moduleName}](${module.getLocationUri(true)})"
       } else ""
     return "$withDoc$footer"
   }

--- a/src/main/resources/org/pkl/lsp/errorMessages.properties
+++ b/src/main/resources/org/pkl/lsp/errorMessages.properties
@@ -125,4 +125,9 @@ unsyncedPklProject=\
 Project is out of sync.
 
 pklCliNotConfigured=\
-Pkl CLI is not configured.
+Pkl CLI is not configured and not found in PATH.
+
+pklCliNotFound=\
+Could not find Pkl CLI in PATH.\n\
+\n\
+To enable richer language features, first install the Pkl CLI: https://pkl-lang.org/main/current/pkl-cli/index.html#installation.


### PR DESCRIPTION
This defines initialization options that clients can send during the initialize request,
to configure the behavior of the server.

This also introduces extended capabilities that clients can notify the server about.

Also:

* Switch some messages from `sendActionableNotification` to `showMessageRequest`, which is a built-in message.
* Look for Pkl CLI on $PATH if not configured by client.
* Render doc comments as normal URIs instead of `command:pkl.open.file`, unless configured to do so.