### PR TITLE
Fix: omit sync notification for files outside workspace

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/PklProjectManager.kt
@@ -128,7 +128,7 @@ class PklProjectManager(project: Project) : Component(project) {
             MessageType.Error,
             """
         Failed to sync project.
-        
+
         ${err.cause!!.stackTraceToString()}
       """
               .trimIndent(),
@@ -182,6 +182,7 @@ class PklProjectManager(project: Project) : Component(project) {
     }
     if (
       event is TextDocumentEvent.Opened &&
+        file.isInWorkspace &&
         file.pklProjectDir != null &&
         file.pklProject == null &&
         project.settingsManager.settings.pklCliPath != null
@@ -344,4 +345,7 @@ class PklProjectManager(project: Project) : Component(project) {
       evaluatorSettings = metadata.evaluatorSettings,
     )
   }
+
+  private val FsFile.isInWorkspace: Boolean
+    get() = workspaceFolders.any { path.startsWith(it) }
 }


### PR DESCRIPTION
This fixes an issue where the sync project notification shows up for files that aren't within any workspaces.