### PR TITLE
Improve handling of VirtualFile

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -109,11 +109,13 @@ sealed class BaseFile : VirtualFile {
       myContents = text
     }
 
+  @Synchronized
   final override fun getModule(): CompletableFuture<PklModule?> {
     if (isDirectory) {
       return CompletableFuture.completedFuture(null)
     }
     if (readError != null) {
+      readError = null
       project.cachedValuesManager.clearCachedValue(cacheKey)
     }
     return project.cachedValuesManager.getCachedValue(cacheKey) {
@@ -134,6 +136,9 @@ sealed class BaseFile : VirtualFile {
     return try {
       logger.log("building $uri")
       val moduleCtx = parser.parseModule(contents)
+      if (readError != null) {
+        readError = null
+      }
       return PklModuleImpl(moduleCtx, this)
     } catch (e: LexParseException) {
       logger.warn("Parser Error building $file: ${e.message}")

--- a/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
@@ -18,10 +18,9 @@ package org.pkl.lsp
 import java.net.URI
 import java.nio.file.*
 import java.util.*
-import java.util.concurrent.ConcurrentHashMap
 
 class VirtualFileManager(project: Project) : Component(project) {
-  private val files: MutableMap<URI, BaseFile> = ConcurrentHashMap()
+  private val files: MutableMap<URI, BaseFile> = Collections.synchronizedMap(WeakHashMap())
 
   fun get(path: Path): VirtualFile? {
     return if (!Files.exists(path)) null else get(path.toUri(), path)


### PR DESCRIPTION
* Unset readError on successful read, and ensure called in synchronized block
* Cache VirtualFiles in a weak map to allow stale files to be garbage collected