### PR TITLE
Fix memory leak: improve cache storage granularity

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -51,7 +51,8 @@ class PklModuleImpl(override val ctx: TreeSitterNode, override val virtualFile: 
 
   override fun cache(context: PklProject?): ModuleMemberCache =
     project.cachedValuesManager.getCachedValue(
-      "PklModule.cache(${virtualFile.uri}, ${context?.projectDir}}"
+      this,
+      "PklModule.cache(${virtualFile.uri}, ${context?.projectDir}}",
     ) {
       val cache = ModuleMemberCache.create(this, context)
       CachedValue(cache, cache.dependencies + project.pklProjectManager.syncTracker)

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -24,6 +24,7 @@ import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitor
 import org.pkl.lsp.type.Type
 import org.pkl.lsp.type.TypeParameterBindings
+import org.pkl.lsp.util.CachedValueDataHolderBase
 
 interface PklNode {
   val project: Project
@@ -650,7 +651,7 @@ abstract class AbstractPklNode(
   override val project: Project,
   override val parent: PklNode?,
   protected open val ctx: TreeSitterNode,
-) : PklNode {
+) : CachedValueDataHolderBase(), PklNode {
   private val childrenByType: Map<KClass<out PklNode>, List<PklNode>> by lazy {
     val self = this
     // use LinkedHashMap to preserve order


### PR DESCRIPTION
Currently, all cached values are stored in a global hashmap, which means that these cached values will never get marked for disposal by the garbage collector.

This introduces a `CachedValueDataHolder`, which allows cached values to be written to it. This allows these cached values to be disposed of when the `CacheValueDataHolder` itself is disposed.