### PR TITLE
Use Zig to cross-compile native libs

### DIFF
--- a/buildSrc/src/main/kotlin/Architecture.kt
+++ b/buildSrc/src/main/kotlin/Architecture.kt
@@ -13,6 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins { `kotlin-dsl` }
+@file:Suppress("MemberVisibilityCanBePrivate")
 
-dependencies { implementation(libs.downloadTaskPlugin) }
+sealed class Architecture(
+  /** The arch name that we use in our own distributions. */
+  val name: String,
+  /** The arch name used by the zig C compiler. */
+  val cName: String,
+) {
+  object Amd64 : Architecture("amd64", "x86_64")
+  object Aarch64 : Architecture("aarch64", "aarch64")
+}

--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -20,10 +20,11 @@ import org.gradle.api.artifacts.VersionCatalog
 import org.gradle.api.artifacts.VersionCatalogsExtension
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.internal.os.OperatingSystem
+import java.nio.file.Path
 
 // `buildInfo` in main build scripts
 // `project.extensions.getByType<BuildInfo>()` in precompiled script plugins
-open class BuildInfo(project: Project) {
+open class BuildInfo(val project: Project) {
   val isCiBuild: Boolean by lazy { System.getenv("CI") != null }
 
   val isReleaseBuild: Boolean by lazy { java.lang.Boolean.getBoolean("releaseBuild") }
@@ -31,6 +32,15 @@ open class BuildInfo(project: Project) {
   val os: OperatingSystem by lazy {
     OperatingSystem.current()
   }
+
+  val arch: Architecture
+    get() {
+      return when (val arch = System.getProperty("os.arch")) {
+        "x86_64", "amd64" -> Architecture.Amd64
+        "aarch64", "arm64" -> Architecture.Aarch64
+        else -> throw RuntimeException("Unsupported architecture: $arch")
+      }
+    }
 
   // could be `commitId: Provider<String> = project.provider { ... }`
   val commitId: String by lazy {
@@ -71,6 +81,16 @@ open class BuildInfo(project: Project) {
   // https://melix.github.io/blog/2021/03/version-catalogs-faq.html#_but_how_can_i_use_the_catalog_in_em_plugins_em_defined_in_code_buildsrc_code
   val libs: VersionCatalog by lazy {
     project.extensions.getByType<VersionCatalogsExtension>().named("libs")
+  }
+
+  val zig: Zig = Zig()
+
+  inner class Zig {
+    val version: String get() = libs.findVersion("zig").get().toString()
+
+    val installDir: Path get() = project.projectDir.toPath().resolve(".gradle/zig/zig-$version")
+
+    val executable: Path get() = installDir.resolve(if (os.isWindows) "zig.exe" else "zig")
   }
 
   init {

--- a/buildSrc/src/main/kotlin/utils.kt
+++ b/buildSrc/src/main/kotlin/utils.kt
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-plugins { `kotlin-dsl` }
+import org.gradle.internal.os.OperatingSystem
 
-dependencies { implementation(libs.downloadTaskPlugin) }
+val OperatingSystem.canonicalName get() = when {
+  isMacOsX -> "macos"
+  isWindows -> "windows"
+  isLinux -> "linux"
+  else -> throw RuntimeException("Unsupported OS: $name")
+}

--- a/buildSrc/src/main/kotlin/zig.gradle.kts
+++ b/buildSrc/src/main/kotlin/zig.gradle.kts
@@ -1,0 +1,72 @@
+/**
+ * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import de.undercouch.gradle.tasks.download.Download
+import de.undercouch.gradle.tasks.download.Verify
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+
+plugins { id("de.undercouch.download") }
+
+val buildInfo = extensions.create<BuildInfo>("buildInfo", project)
+
+private val downloadFile
+  get() = project.layout.buildDirectory.file("tmp/zig.$extension").get().asFile
+
+private val extension: String
+  get() = if (buildInfo.os.isWindows) "zip" else "tar.xz"
+
+val downloadZig by
+  tasks.registering(Download::class) {
+    onlyIf { !buildInfo.zig.executable.exists() }
+    doLast { println("Downloaded Zig to $downloadFile") }
+
+    src(
+      "https://ziglang.org/download/${buildInfo.zig.version}/zig-${buildInfo.os.canonicalName}-${buildInfo.arch.cName}-${buildInfo.zig.version}.$extension"
+    )
+    dest(downloadFile)
+    overwrite(true)
+  }
+
+val verifyZig by
+  tasks.registering(Verify::class) {
+    dependsOn(downloadZig)
+    src(downloadFile)
+    onlyIf { !buildInfo.zig.executable.exists() }
+    checksum(
+      buildInfo.libs
+        .findVersion("zigSha256-${buildInfo.os.canonicalName}-${buildInfo.arch.name}")
+        .get()
+        .toString()
+    )
+    algorithm("SHA-256")
+  }
+
+val installZig by
+  tasks.registering {
+    onlyIf { !buildInfo.zig.executable.exists() }
+    dependsOn(verifyZig)
+
+    doLast {
+      buildInfo.zig.installDir.createDirectories()
+      println("Extracting $downloadFile into ${buildInfo.zig.installDir}")
+      // faster and more reliable than Gradle's `copy { from tarTree() }`
+      exec {
+        workingDir = file(buildInfo.zig.installDir)
+        executable = "tar"
+        args("--strip-components=1", "-xf", downloadFile)
+      }
+    }
+  }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,24 +2,32 @@
 assertj = "3.26.3"
 antlr = "4.+"
 clikt = "4.4.0"
+downloadTaskPlugin = "5.6.0"
 jtreesitter = "0.23.1"
 junit-jupiter = "5.10.2"
 kotlin = "2.0.0"
 kotlinx = "1.7.1"
 ktfmt = "0.51"
 lsp4j = "0.23.1"
-node = "20.10.0"
-nodeGradle = "3.2.0"
 pkl = "0.26.3"
 shadowPlugin = "8.1.1"
 spotless = "6.21.0"
 treeSitterRepo = "v0.23.0" # git tag name
 treeSitterPklRepo = "b867391" # TODO switch to tag
+zig = "0.13.0" # used for cross-compiling tree-sitter libs
+
+# Only need checksums for distributions that we might run builds on.
+# Computed with `curl -s <DOWNLOAD_URL> | shasum -a 256`.
+# Download links found here: https://ziglang.org/download/
+zigSha256-macos-aarch64 = "46fae219656545dfaf4dce12fb4e8685cec5b51d721beee9389ab4194d43394c"
+zigSha256-linux-amd64 = "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea"
+zigSha256-windows-amd64 = "d859994725ef9402381e557c60bb57497215682e355204d754ee3df75ee3c158"
 
 [libraries]
 antlr = { group = "com.tunnelvisionlabs", name = "antlr4", version.ref = "antlr" }
 assertJ = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
+downloadTaskPlugin = { group = "de.undercouch", name = "gradle-download-task", version.ref = "downloadTaskPlugin" }
 jtreesitter = { group = "io.github.tree-sitter", name = "jtreesitter", version.ref = "jtreesitter" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 kotlinxSerializationJson = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx" }
@@ -29,6 +37,5 @@ pklCore = { group = "org.pkl-lang", name = "pkl-core", version.ref = "pkl" }
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-nodeGradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }
 shadow = { id = "com.github.johnrengelman.shadow", version.ref = "shadowPlugin" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
This uses Zig to compile the native libraries for macOS/linux/windows for the aarch64/amd64 architectures.

This also removes Node.js stuff, which is no longer necessary because we don't use the tree-sitter CLI anymore to build these libraries.