### PR TITLE
improve completions for unqualified access

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/LSPUtil.kt
+++ b/src/main/kotlin/org/pkl/lsp/LSPUtil.kt
@@ -294,3 +294,13 @@ fun decodePath(path: String): String {
 }
 
 val gson: Gson = Gson()
+
+fun editSource(source: String, line: Int, col: Int, edit: String): String {
+  val lines = source.lineSequence().toMutableList()
+  if (lines.size <= line) return source
+
+  val txt = lines[line]
+  val end = col.coerceAtMost(txt.length)
+  lines[line] = txt.substring(0, end) + edit + txt.substring(end)
+  return lines.joinToString("\n")
+}

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -18,7 +18,6 @@ package org.pkl.lsp.ast
 import io.github.treesitter.jtreesitter.Node
 import java.net.URI
 import java.net.URLEncoder
-import java.util.*
 import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import org.eclipse.lsp4j.Location

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -39,6 +39,7 @@ interface PklNode {
   val text: String
   /** True if tree-sitter inserted this node. */
   val isMissing: Boolean
+  val source: String
 
   fun <R> accept(visitor: PklVisitor<R>): R?
 
@@ -703,6 +704,8 @@ abstract class AbstractPklNode(
   override val text: String by lazy { ctx.text }
 
   override val isMissing: Boolean by lazy { ctx.isMissing }
+
+  override val source: String by lazy { ctx.source }
 
   override fun hashCode(): Int {
     return ctx.hashCode()

--- a/src/main/kotlin/org/pkl/lsp/ast/TreeSitterNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/TreeSitterNode.kt
@@ -34,6 +34,8 @@ class TreeSitterNode(private val ctx: Node, private val executor: ExecutorServic
 
   val range: Range by lazy { call { ctx.range } }
 
+  val source: String by lazy { call { ctx.tree.text } }
+
   val children: List<TreeSitterNode> by lazy {
     call { ctx.children.map { TreeSitterNode(it, executor) } }
   }

--- a/src/main/kotlin/org/pkl/lsp/completion/UnqualifiedAccessCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/UnqualifiedAccessCompletionProvider.kt
@@ -23,6 +23,7 @@ import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.decapitalized
+import org.pkl.lsp.editSource
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitors
 import org.pkl.lsp.resolvers.Resolvers
@@ -236,18 +237,6 @@ class UnqualifiedAccessCompletionProvider(private val project: Project) : Comple
     val expr = node.parentOfType<PklExpr>() ?: return false
     val type = expr.inferExprTypeFromContext(base, mapOf(), context)
     return isClassOrTypeAlias(type)
-  }
-
-  private fun editSource(source: String, line: Int, col: Int, edit: String): String {
-    return source
-      .lines()
-      .mapIndexed { i, txt ->
-        if (i == line) {
-          val end = col.coerceAtMost(txt.length)
-          txt.substring(0, end) + edit + txt.substring(end)
-        } else txt
-      }
-      .joinToString("\n")
   }
 
   companion object {


### PR DESCRIPTION
This will allow unqualified completions when the user didn't type anything:

```pkl
foo = <caret>

foo {
  <caret>
}

bar = let (x = <caret>) x
```