### PR TITLE
fix binary expressions AST generation

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -15,6 +15,7 @@
  */
 package org.pkl.lsp.ast
 
+import java.util.EnumSet
 import org.pkl.lsp.*
 import org.pkl.lsp.LSPUtil.firstInstanceOf
 import org.pkl.lsp.packages.dto.PklProject
@@ -400,15 +401,42 @@ class PklLogicalNotExprImpl(
   }
 }
 
+abstract class PklBinExprImpl(
+  override val project: Project,
+  override val parent: PklNode,
+  override val ctx: TreeSitterNode,
+) : AbstractPklNode(project, parent, ctx), PklBinExpr {
+  private val binOps =
+    EnumSet.of(
+      TokenType.STAR,
+      TokenType.DIV,
+      TokenType.INT_DIV,
+      TokenType.MOD,
+      TokenType.PLUS,
+      TokenType.MINUS,
+      TokenType.GT,
+      TokenType.LT,
+      TokenType.GTE,
+      TokenType.LTE,
+      TokenType.EQUAL,
+      TokenType.NOT_EQUAL,
+      TokenType.AND,
+      TokenType.OR,
+      TokenType.PIPE,
+      TokenType.POW,
+      TokenType.COALESCE,
+    )
+  private val exprs: List<PklExpr> by lazy { children.filterIsInstance<PklExpr>() }
+  override val leftExpr: PklExpr by lazy { exprs[0] }
+  override val rightExpr: PklExpr by lazy { exprs[1] }
+  override val operator: Terminal by lazy { terminals.find { it.type in binOps }!! }
+}
+
 class PklAdditiveExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklAdditiveExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklAdditiveExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitAdditiveExpr(this)
   }
@@ -418,11 +446,7 @@ class PklMultiplicativeExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklMultiplicativeExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklMultiplicativeExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitMultiplicativeExpr(this)
   }
@@ -432,11 +456,7 @@ class PklComparisonExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklComparisonExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklComparisonExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitComparisonExpr(this)
   }
@@ -446,11 +466,7 @@ class PklEqualityExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklEqualityExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklEqualityExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitEqualityExpr(this)
   }
@@ -460,11 +476,7 @@ class PklExponentiationExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklExponentiationExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklExponentiationExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitExponentiationExpr(this)
   }
@@ -474,11 +486,7 @@ class PklLogicalAndExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklLogicalAndExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklLogicalAndExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitLogicalAndExpr(this)
   }
@@ -488,11 +496,7 @@ class PklLogicalOrExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklLogicalOrExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklLogicalOrExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitLogicalOrExpr(this)
   }
@@ -502,11 +506,7 @@ class PklNullCoalesceExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklNullCoalesceExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklNullCoalesceExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitNullCoalesceExpr(this)
   }
@@ -532,11 +532,7 @@ class PklPipeExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : AbstractPklNode(project, parent, ctx), PklPipeExpr {
-  override val leftExpr: PklExpr by lazy { ctx.children[0].toNode(project, this) as PklExpr }
-  override val rightExpr: PklExpr by lazy { ctx.children[2].toNode(project, this) as PklExpr }
-  override val operator: Terminal by lazy { terminals[0] }
-
+) : PklBinExprImpl(project, parent, ctx), PklPipeExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitPipeExpr(this)
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -15,7 +15,6 @@
  */
 package org.pkl.lsp.ast
 
-import java.util.EnumSet
 import org.pkl.lsp.*
 import org.pkl.lsp.LSPUtil.firstInstanceOf
 import org.pkl.lsp.packages.dto.PklProject
@@ -405,38 +404,20 @@ abstract class PklBinExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
+  open val tsOperator: TreeSitterNode,
 ) : AbstractPklNode(project, parent, ctx), PklBinExpr {
-  private val binOps =
-    EnumSet.of(
-      TokenType.STAR,
-      TokenType.DIV,
-      TokenType.INT_DIV,
-      TokenType.MOD,
-      TokenType.PLUS,
-      TokenType.MINUS,
-      TokenType.GT,
-      TokenType.LT,
-      TokenType.GTE,
-      TokenType.LTE,
-      TokenType.EQUAL,
-      TokenType.NOT_EQUAL,
-      TokenType.AND,
-      TokenType.OR,
-      TokenType.PIPE,
-      TokenType.POW,
-      TokenType.COALESCE,
-    )
   private val exprs: List<PklExpr> by lazy { children.filterIsInstance<PklExpr>() }
   override val leftExpr: PklExpr by lazy { exprs[0] }
   override val rightExpr: PklExpr by lazy { exprs[1] }
-  override val operator: Terminal by lazy { terminals.find { it.type in binOps }!! }
+  override val operator: Terminal by lazy { tsOperator.toTerminal(parent)!! }
 }
 
 class PklAdditiveExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklAdditiveExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklAdditiveExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitAdditiveExpr(this)
   }
@@ -446,7 +427,8 @@ class PklMultiplicativeExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklMultiplicativeExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklMultiplicativeExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitMultiplicativeExpr(this)
   }
@@ -456,7 +438,8 @@ class PklComparisonExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklComparisonExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklComparisonExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitComparisonExpr(this)
   }
@@ -466,7 +449,8 @@ class PklEqualityExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklEqualityExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklEqualityExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitEqualityExpr(this)
   }
@@ -476,7 +460,8 @@ class PklExponentiationExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklExponentiationExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklExponentiationExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitExponentiationExpr(this)
   }
@@ -486,7 +471,8 @@ class PklLogicalAndExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklLogicalAndExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklLogicalAndExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitLogicalAndExpr(this)
   }
@@ -496,7 +482,8 @@ class PklLogicalOrExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklLogicalOrExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklLogicalOrExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitLogicalOrExpr(this)
   }
@@ -506,7 +493,8 @@ class PklNullCoalesceExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklNullCoalesceExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklNullCoalesceExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitNullCoalesceExpr(this)
   }
@@ -532,7 +520,8 @@ class PklPipeExprImpl(
   override val project: Project,
   override val parent: PklNode,
   override val ctx: TreeSitterNode,
-) : PklBinExprImpl(project, parent, ctx), PklPipeExpr {
+  override val tsOperator: TreeSitterNode,
+) : PklBinExprImpl(project, parent, ctx, tsOperator), PklPipeExpr {
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitPipeExpr(this)
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -824,34 +824,47 @@ fun TreeSitterNode.toNode(project: Project, parent: PklNode?): PklNode? {
         "!" -> PklLogicalNotExprImpl(project, parent!!, this)
         else -> PklNonNullExprImpl(project, parent!!, this)
       }
-    "binaryExprRightAssoc" -> {
-      val operator = children.find { it.type == "**" || it.type == "??" }
-      when (operator?.type) {
-        "**" -> PklExponentiationExprImpl(project, parent!!, this)
-        "??" -> PklNullCoalesceExprImpl(project, parent!!, this)
-        else -> throw RuntimeException("Unknown binary operator in expr `$text`")
-      }
-    }
+    "binaryExprRightAssoc",
     "binaryExpr" -> {
       val binOps =
-        setOf("*", "/", "~/", "%", "+", "-", "<", ">", "<=", ">=", "==", "!=", "&&", "||", "|>")
+        setOf(
+          "*",
+          "/",
+          "~/",
+          "%",
+          "+",
+          "-",
+          "<",
+          ">",
+          "<=",
+          ">=",
+          "==",
+          "!=",
+          "&&",
+          "||",
+          "|>",
+          "**",
+          "??",
+        )
       val operator = children.find { it.type in binOps }
       when (operator?.type) {
         "*",
         "/",
         "~/",
-        "%" -> PklMultiplicativeExprImpl(project, parent!!, this)
+        "%" -> PklMultiplicativeExprImpl(project, parent!!, this, operator)
         "+",
-        "-" -> PklAdditiveExprImpl(project, parent!!, this)
+        "-" -> PklAdditiveExprImpl(project, parent!!, this, operator)
         "<",
         ">",
         "<=",
-        ">=" -> PklComparisonExprImpl(project, parent!!, this)
+        ">=" -> PklComparisonExprImpl(project, parent!!, this, operator)
         "==",
-        "!=" -> PklEqualityExprImpl(project, parent!!, this)
-        "&&" -> PklLogicalAndExprImpl(project, parent!!, this)
-        "||" -> PklLogicalOrExprImpl(project, parent!!, this)
-        "|>" -> PklPipeExprImpl(project, parent!!, this)
+        "!=" -> PklEqualityExprImpl(project, parent!!, this, operator)
+        "&&" -> PklLogicalAndExprImpl(project, parent!!, this, operator)
+        "||" -> PklLogicalOrExprImpl(project, parent!!, this, operator)
+        "|>" -> PklPipeExprImpl(project, parent!!, this, operator)
+        "**" -> PklExponentiationExprImpl(project, parent!!, this, operator)
+        "??" -> PklNullCoalesceExprImpl(project, parent!!, this, operator)
         else -> throw RuntimeException("Unknown binary operator in expr `$text`")
       }
     }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -824,17 +824,19 @@ fun TreeSitterNode.toNode(project: Project, parent: PklNode?): PklNode? {
         "!" -> PklLogicalNotExprImpl(project, parent!!, this)
         else -> PklNonNullExprImpl(project, parent!!, this)
       }
-    "binaryExprRightAssoc" ->
-      when (children[1].type) {
+    "binaryExprRightAssoc" -> {
+      val operator = children.find { it.type == "**" || it.type == "??" }
+      when (operator?.type) {
         "**" -> PklExponentiationExprImpl(project, parent!!, this)
         "??" -> PklNullCoalesceExprImpl(project, parent!!, this)
-        "lineComment",
-        "blockComment" -> null
-        "ERROR" -> PklErrorImpl(project, parent!!, this)
-        else -> throw RuntimeException("Unknown binary operator `${children[1].type}`")
+        else -> throw RuntimeException("Unknown binary operator in expr `$text`")
       }
-    "binaryExpr" ->
-      when (children[1].type) {
+    }
+    "binaryExpr" -> {
+      val binOps =
+        setOf("*", "/", "~/", "%", "+", "-", "<", ">", "<=", ">=", "==", "!=", "&&", "||", "|>")
+      val operator = children.find { it.type in binOps }
+      when (operator?.type) {
         "*",
         "/",
         "~/",
@@ -850,11 +852,9 @@ fun TreeSitterNode.toNode(project: Project, parent: PklNode?): PklNode? {
         "&&" -> PklLogicalAndExprImpl(project, parent!!, this)
         "||" -> PklLogicalOrExprImpl(project, parent!!, this)
         "|>" -> PklPipeExprImpl(project, parent!!, this)
-        "lineComment",
-        "blockComment" -> null
-        "ERROR" -> PklErrorImpl(project, parent!!, this)
-        else -> throw RuntimeException("Unknown binary operator `${children[1].type}`")
+        else -> throw RuntimeException("Unknown binary operator in expr `$text`")
       }
+    }
     "isExpr" -> PklTypeTestExprImpl(project, parent!!, this)
     "asExpr" -> PklTypeTestExprImpl(project, parent!!, this)
     "ifExpr" -> PklIfExprImpl(project, parent!!, this)


### PR DESCRIPTION
While generating the AST for binary expressions we were making wrong assumptions about where the children should be located. This fixes the generation so expressions with comments, errors, or any other kind of node in between will still parse correctly.