### PR TITLE
Remove dependency on pkl-core

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ val treeSitterRepoDir = layout.buildDirectory.dir("repos/tree-sitter")
 dependencies {
   implementation(kotlin("reflect"))
   implementation(libs.clikt)
-  implementation(libs.pklCore)
+  runtimeOnly(libs.pklStdlib)
   implementation(libs.lsp4j)
   implementation(libs.kotlinxSerializationJson)
   implementation(libs.jtreesitter)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,7 +30,7 @@ jtreesitter = { group = "io.github.tree-sitter", name = "jtreesitter", version.r
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit-jupiter" }
 kotlinxSerializationJson = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx" }
 lsp4j = { group = "org.eclipse.lsp4j", name = "org.eclipse.lsp4j", version.ref = "lsp4j" }
-pklCore = { group = "org.pkl-lang", name = "pkl-core", version.ref = "pkl" }
+pklStdlib = { group = "org.pkl-lang", name = "pkl-stdlib", version.ref = "pkl" }
 
 [plugins]
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }

--- a/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
@@ -15,8 +15,6 @@
  */
 package org.pkl.lsp
 
-import org.pkl.core.Release
-import org.pkl.core.Version
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.type.Type
 
@@ -56,9 +54,6 @@ class PklBaseModule(project: Project) : Component(project) {
     this.types = types
     this.methods = methods
   }
-
-  val pklVersion: Version
-    get() = Release.current().version()
 
   val listConstructor: PklClassMethod = method("List")
   val setConstructor: PklClassMethod = method("Set")

--- a/src/main/kotlin/org/pkl/lsp/Stdlib.kt
+++ b/src/main/kotlin/org/pkl/lsp/Stdlib.kt
@@ -24,7 +24,7 @@ import kotlin.io.path.name
 class Stdlib(project: Project) : Component(project) {
   @Suppress("MemberVisibilityCanBePrivate")
   val files: Map<String, VirtualFile> by lazy {
-    val baseModuleUri = javaClass.getResource("/org/pkl/core/stdlib/base.pkl")!!.toURI()
+    val baseModuleUri = javaClass.getResource("/org/pkl/stdlib/base.pkl")!!.toURI()
     project.virtualFileManager.ensureJarFileSystem(baseModuleUri)
     val path = Path.of(baseModuleUri)
     path.parent

--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -21,8 +21,6 @@ import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import javax.naming.OperationNotSupportedException
 import kotlin.io.path.*
-import org.pkl.core.module.ModuleKeyFactories.file
-import org.pkl.core.util.IoUtils
 import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklModuleImpl
 import org.pkl.lsp.packages.PackageDependency
@@ -149,7 +147,7 @@ sealed class BaseFile : VirtualFile, CachedValueDataHolderBase() {
       }
       return PklModuleImpl(moduleCtx, this)
     } catch (e: Exception) {
-      logger.warn("Error building $file: ${e.message} ${e.stackTraceToString()}")
+      logger.warn("Error building file: ${e.message} ${e.stackTraceToString()}")
       readError = e
       null
     }
@@ -221,7 +219,10 @@ class StdlibFile(moduleName: String, override val project: Project) : BaseFile()
   override fun resolve(path: String): VirtualFile? = null
 
   override fun doReadContents(): String {
-    return IoUtils.readClassPathResourceAsString(javaClass, "/org/pkl/core/stdlib/$name.pkl")
+    return javaClass.getResourceAsStream("/org/pkl/stdlib/$name.pkl")!!.bufferedReader().use {
+      reader ->
+      reader.readText()
+    }
   }
 }
 


### PR DESCRIPTION
We only need pkl-stdlib; don't need to bring in the entire pkl-core.