### PR TITLE
Touch up publishing

### DIFF
--- a/.circleci/config.pkl
+++ b/.circleci/config.pkl
@@ -122,13 +122,13 @@ jobs {
     steps {
       new AttachWorkspaceStep { at = "." }
       new RunStep {
-        name = "Publish release on GitHub"
+        name = "Publish release to GitHub"
         command = #"""
           gh release create "${CIRCLE_TAG}" \
             --title "${CIRCLE_TAG}" \
             --target "${CIRCLE_SHA1}" \
             --verify-tag \
-            --notes "Release notes: https://pkl-lang.org/pkl-lsp/current/release-notes/changelog.html#release-${CIRCLE_TAG}" \
+            --notes "Release version ${CIRCLE_TAG}" \
             --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" \
             build/libs/*
           """#
@@ -143,7 +143,9 @@ jobs {
     }
     steps {
       "checkout"
+      new AttachWorkspaceStep { at = "." }
       new RunStep {
+        name = "Publish to Maven Central"
         command = """
           ./gradlew -DreleaseBuild=true publishToSonatype closeAndReleaseSonatypeStagingRepository
           """
@@ -158,24 +160,10 @@ jobs {
     }
     steps {
       "checkout"
+      new AttachWorkspaceStep { at = "." }
       new RunStep {
-        command = "./gradlew build publishToSonatype"
-      }
-    }
-  }
-  ["do-release"] {
-    docker {
-      new { image = "maniator/gh:v2.40.1" }
-    }
-    steps {
-      new AttachWorkspaceStep {
-        at = "."
-      }
-      new RunStep {
-        name = "gh release"
-        command = """
-          echo "release"
-          """
+        name = "Publish snapshot release"
+        command = "./gradlew publishToSonatype"
       }
     }
   }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,35 +64,32 @@ jobs:
             --title "${CIRCLE_TAG}" \
             --target "${CIRCLE_SHA1}" \
             --verify-tag \
-            --notes "Release notes: https://pkl-lang.org/pkl-lsp/current/release-notes/changelog.html#release-${CIRCLE_TAG}" \
+            --notes "Release version ${CIRCLE_TAG}" \
             --repo "${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}" \
             build/libs/*
-        name: Publish release on GitHub
+        name: Publish release to GitHub
     docker:
     - image: maniator/gh:v2.40.1
   deploy-release:
     steps:
     - checkout
+    - attach_workspace:
+        at: '.'
     - run:
         command: ./gradlew -DreleaseBuild=true publishToSonatype closeAndReleaseSonatypeStagingRepository
+        name: Publish to Maven Central
     docker:
     - image: cimg/openjdk:21.0
   deploy-snapshot:
     steps:
     - checkout
-    - run:
-        command: ./gradlew build publishToSonatype
-    docker:
-    - image: cimg/openjdk:21.0
-  do-release:
-    steps:
     - attach_workspace:
         at: '.'
     - run:
-        command: echo "release"
-        name: gh release
+        command: ./gradlew publishToSonatype
+        name: Publish snapshot release
     docker:
-    - image: maniator/gh:v2.40.1
+    - image: cimg/openjdk:21.0
 workflows:
   prb:
     jobs:

--- a/README.adoc
+++ b/README.adoc
@@ -3,20 +3,17 @@
 This is an implementation of the link:https://microsoft.github.io/language-server-protocol/[Language Server Protocol]
 for link:https://pkl-lang.org[Pkl].
 
-== Running the LSP in Visual Studio Code
-
-Make sure you have the vscode link:https://pkl-lang.org/vscode/current/installation.html[plugin] installed.
-
-Go to `Settings` -> `Pkl: Path` and set the path to the lsp executable.
-You need to have Java >=17 in your path.
-
 == Features
 
 * [x] Diagnostics (WIP)
 * [x] Hover
 * [x] Go to definition
-* [ ] Auto complete (WIP: only `.` auto complete is support at the moment)
+* [x] Auto complete (WIP: definition level access still needed)
+* [x] Project syncing
+* [x] Package downloading
 * [ ] Rename
 * [ ] Find references
 * [ ] Code lens
 * [ ] Formatting
+* [ ] Type checking
+* [ ] Quick fixes

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -394,7 +394,6 @@ publishing {
       artifact(stagedShadowJar.singleFile) {
         classifier = null
         extension = "jar"
-        builtBy(tasks.shadowJar)
       }
       pom {
         name.set("pkl-lsp")


### PR DESCRIPTION
* Don't build before publishToSonatype
* Attach workspaces for various publish steps
* Remove `builtBy` marker for publication
* Release notes: don't link to website that doesn't exist