### PR TITLE
Fix resolve variable in member links

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/documentation/DocCommentMemberLinkProcessor.kt
+++ b/src/main/kotlin/org/pkl/lsp/documentation/DocCommentMemberLinkProcessor.kt
@@ -119,7 +119,7 @@ object DocCommentMemberLinkProcessor {
             imports
               .find { it.memberName == variableName }
               ?.let { import ->
-                if (import.isGlob) import else import.resolveModules(context).first()
+                if (import.isGlob) import else import.resolveModules(context).firstOrNull()
               }
               ?: cache(context).typeDefsAndProperties[variableName]
               ?: project.pklBaseModule.module.cache(null).typeDefsAndProperties[variableName]


### PR DESCRIPTION
Handle an edge case where an import might have a name but the import is not resolvable.