### PR TITLE
Rename classes for consistency

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/LspUtil.kt
+++ b/src/main/kotlin/org/pkl/lsp/LspUtil.kt
@@ -43,7 +43,7 @@ private const val SIGNIFICAND_BITS = 52
 
 private const val IMPLICIT_BIT: Long = SIGNIFICAND_MASK + 1
 
-object LSPUtil {
+object LspUtil {
   fun Span.toRange(): Range {
     val start = Position(beginLine - 1, beginCol - 1)
     val end = Position(endLine - 1, endCol - 1)

--- a/src/main/kotlin/org/pkl/lsp/PklLsp.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklLsp.kt
@@ -18,9 +18,9 @@ package org.pkl.lsp
 import org.eclipse.lsp4j.jsonrpc.Launcher
 import org.eclipse.lsp4j.launch.LSPLauncher
 
-object PklLSP {
+object PklLsp {
   fun run(verbose: Boolean) {
-    val server = PklLSPServer(verbose)
+    val server = PklLspServer(verbose)
     val launcher = createLauncher(server)
 
     val client = launcher.remoteProxy
@@ -30,7 +30,7 @@ object PklLSP {
     future.get()
   }
 
-  private fun createLauncher(server: PklLSPServer): Launcher<PklLanguageClient> =
+  private fun createLauncher(server: PklLspServer): Launcher<PklLanguageClient> =
     with(LSPLauncher.Builder<PklLanguageClient>()) {
       setLocalService(server)
       setRemoteInterface(PklLanguageClient::class.java)

--- a/src/main/kotlin/org/pkl/lsp/PklLspServer.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklLspServer.kt
@@ -27,7 +27,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonRequest
 import org.eclipse.lsp4j.services.*
 import org.pkl.lsp.packages.dto.PackageUri
 
-class PklLSPServer(val verbose: Boolean) : LanguageServer {
+class PklLspServer(val verbose: Boolean) : LanguageServer {
   internal val project: Project = Project(this)
   private lateinit var client: PklLanguageClient
   private lateinit var logger: ClientLogger

--- a/src/main/kotlin/org/pkl/lsp/Project.kt
+++ b/src/main/kotlin/org/pkl/lsp/Project.kt
@@ -24,7 +24,7 @@ import org.pkl.lsp.services.*
 import org.pkl.lsp.treesitter.PklParser
 import org.pkl.lsp.util.CachedValuesManager
 
-class Project(private val server: PklLSPServer) {
+class Project(private val server: PklLspServer) {
   val stdlib: Stdlib by lazy { Stdlib(this) }
 
   val pklBaseModule: PklBaseModule by lazy { PklBaseModule(this) }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/PklDiagnostic.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/PklDiagnostic.kt
@@ -17,7 +17,7 @@ package org.pkl.lsp.analyzers
 
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
-import org.pkl.lsp.LSPUtil.toRange
+import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.actions.PklCodeAction
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.Span

--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -17,7 +17,7 @@ package org.pkl.lsp.ast
 
 import io.github.treesitter.jtreesitter.Node
 import org.pkl.lsp.*
-import org.pkl.lsp.LSPUtil.firstInstanceOf
+import org.pkl.lsp.LspUtil.firstInstanceOf
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitor
 import org.pkl.lsp.resolvers.ResolveVisitors

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -24,7 +24,7 @@ import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
 import org.pkl.lsp.*
 import org.pkl.lsp.FsFile
-import org.pkl.lsp.LSPUtil.toRange
+import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.StdlibFile
 import org.pkl.lsp.ast.PklModuleUriImpl.Companion.resolve
 import org.pkl.lsp.ast.PklModuleUriImpl.Companion.resolveGlob

--- a/src/main/kotlin/org/pkl/lsp/ast/Member.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Member.kt
@@ -16,7 +16,7 @@
 package org.pkl.lsp.ast
 
 import io.github.treesitter.jtreesitter.Node
-import org.pkl.lsp.LSPUtil.firstInstanceOf
+import org.pkl.lsp.LspUtil.firstInstanceOf
 import org.pkl.lsp.PklVisitor
 import org.pkl.lsp.Project
 import org.pkl.lsp.packages.dto.PklProject

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -18,7 +18,7 @@ package org.pkl.lsp.ast
 import io.github.treesitter.jtreesitter.Node
 import java.net.URI
 import org.pkl.lsp.*
-import org.pkl.lsp.LSPUtil.firstInstanceOf
+import org.pkl.lsp.LspUtil.firstInstanceOf
 import org.pkl.lsp.VirtualFile
 import org.pkl.lsp.packages.Dependency
 import org.pkl.lsp.packages.dto.PklProject

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -21,7 +21,7 @@ import org.pkl.lsp.*
 import org.pkl.lsp.FsFile
 import org.pkl.lsp.HttpsFile
 import org.pkl.lsp.JarFile
-import org.pkl.lsp.LSPUtil.firstInstanceOf
+import org.pkl.lsp.LspUtil.firstInstanceOf
 import org.pkl.lsp.VirtualFile
 import org.pkl.lsp.packages.dto.PackageUri
 import org.pkl.lsp.packages.dto.PklProject

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -16,7 +16,7 @@
 package org.pkl.lsp.ast
 
 import io.github.treesitter.jtreesitter.Node
-import org.pkl.lsp.LSPUtil.firstInstanceOf
+import org.pkl.lsp.LspUtil.firstInstanceOf
 import org.pkl.lsp.PklVisitor
 import org.pkl.lsp.Project
 import org.pkl.lsp.packages.dto.PklProject

--- a/src/main/kotlin/org/pkl/lsp/cli/LspCommand.kt
+++ b/src/main/kotlin/org/pkl/lsp/cli/LspCommand.kt
@@ -19,7 +19,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
-import org.pkl.lsp.PklLSP
+import org.pkl.lsp.PklLsp
 import org.pkl.lsp.Release
 
 class LspCommand :
@@ -38,6 +38,6 @@ class LspCommand :
       .flag(default = false)
 
   override fun run() {
-    PklLSP.run(verbose)
+    PklLsp.run(verbose)
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
@@ -24,7 +24,7 @@ import kotlin.io.path.*
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.pkl.lsp.*
-import org.pkl.lsp.LSPUtil.toRange
+import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.documentation.toMarkdown
 import org.pkl.lsp.packages.dto.PackageAssetUri

--- a/src/main/kotlin/org/pkl/lsp/completion/StringLiteralTypeCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/StringLiteralTypeCompletionProvider.kt
@@ -18,7 +18,7 @@ package org.pkl.lsp.completion
 import org.eclipse.lsp4j.*
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.pkl.lsp.Component
-import org.pkl.lsp.LSPUtil.toRange
+import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*

--- a/src/main/kotlin/org/pkl/lsp/features/CodeActionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/CodeActionFeature.kt
@@ -22,7 +22,7 @@ import org.eclipse.lsp4j.CodeActionParams
 import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.pkl.lsp.Component
-import org.pkl.lsp.LSPUtil.toRange
+import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.Project
 
 class CodeActionFeature(project: Project) : Component(project) {

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
@@ -22,12 +22,12 @@ import org.pkl.lsp.ast.PklClassProperty
 import org.pkl.lsp.ast.PklModuleClause
 import org.pkl.lsp.packages.dto.PackageUri
 
-class GoToDefinitionPackagesTest : LSPTestBase() {
+class GoToDefinitionPackagesTest : LspTestBase() {
   companion object {
     @BeforeAll
     @JvmStatic
     fun beforeAll() {
-      LSPTestBase.beforeAll()
+      LspTestBase.beforeAll()
       fakeProject.pklCli
         .downloadPackage(
           listOf(

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
@@ -19,7 +19,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.pkl.lsp.ast.*
 
-class GoToDefinitionTest : LSPTestBase() {
+class GoToDefinitionTest : LspTestBase() {
   @Test
   fun `resolve property name in scope`() {
     createPklFile(

--- a/src/test/kotlin/org/pkl/lsp/HoverTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/HoverTest.kt
@@ -18,7 +18,7 @@ package org.pkl.lsp
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
-class HoverTest : LSPTestBase() {
+class HoverTest : LspTestBase() {
   @Test
   fun `hover produces docs`() {
     createPklFile(

--- a/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
@@ -30,15 +30,15 @@ import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.findBySpan
 
-abstract class LSPTestBase {
+abstract class LspTestBase {
   companion object {
-    private lateinit var server: PklLSPServer
+    private lateinit var server: PklLspServer
     internal lateinit var fakeProject: Project
 
     @JvmStatic
     @BeforeAll
     fun beforeAll() {
-      server = PklLSPServer(true).also { it.connect(TestLanguageClient) }
+      server = PklLspServer(true).also { it.connect(TestLanguageClient) }
       fakeProject = server.project
       System.getProperty("pklExecutable")?.let { executablePath ->
         TestLanguageClient.settings["Pkl" to "pkl.cli.path"] = executablePath

--- a/src/test/kotlin/org/pkl/lsp/ParserSnippetTestEngine.kt
+++ b/src/test/kotlin/org/pkl/lsp/ParserSnippetTestEngine.kt
@@ -67,7 +67,7 @@ class ParserSnippetTestEngine : HierarchicalTestEngine<ParserSnippetTestEngine.E
     return outputDir.resolve(relativePath.toString().dropLast(4) + ".txt")
   }
 
-  private val project = Project(PklLSPServer(true))
+  private val project = Project(PklLspServer(true))
 
   private fun PklNode.render(): String {
     return buildString {

--- a/src/test/kotlin/org/pkl/lsp/ParserTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/ParserTest.kt
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test
 import org.pkl.lsp.ast.*
 
 class ParserTest {
-  private val project = Project(PklLSPServer(true))
+  private val project = Project(PklLspServer(true))
   private val parser = project.pklParser
 
   @Test

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.pkl.lsp.services.PklWorkspaceState
 
-class SyncProjectsTest : LSPTestBase() {
+class SyncProjectsTest : LspTestBase() {
 
   private lateinit var projectFile: Path
 


### PR DESCRIPTION
Change capitalization of the following classes:
LSPTestBase -> LspTestBase
LSPUtil -> LspUtil
PklLSP -> PklLsp
PklLSPServer -> PklLspServer

This renaming is consistent with the existing classes LspCommand, PklCli, etc.