### PR TITLE
Upgrade to java-tree-sitter 0.24

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,13 +85,12 @@ idea { module { generatedSourceDirs.add(jsitterMonkeyPatchSourceDir.get().asFile
  * `java.library.path`.
  *
  * This patches its source code so that we can control exactly where the tree-sitter library
- * resides. It also patches the `Tree` class so its objects can be accessed from multiple threads.
- * As we never modify trees, they are safe to be accessed.
+ * resides.
  */
 val monkeyPatchTreeSitter by
   tasks.registering(Copy::class) {
     from(zipTree(jtreeSitterSources.singleFile)) {
-      include("**/TreeSitter.java", "**/Tree.java")
+      include("**/TreeSitter.java")
       filter { line ->
         when {
           line.contains("static final SymbolLookup") ->
@@ -103,10 +102,6 @@ val monkeyPatchTreeSitter by
             import org.pkl.lsp.treesitter.NativeLibraries;
           """
               .trimIndent()
-          line.contains("Arena.ofConfined") -> line.replace("ofConfined", "ofShared")
-          line.contains("jspecify") -> ""
-          line.contains("@NullMarked") -> ""
-          line.contains("@Nullable") -> line.replace("@Nullable ", "")
           else -> line
         }
       }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 assertj = "3.26.3"
 clikt = "4.4.0"
 downloadTaskPlugin = "5.6.0"
-jtreesitter = "0.23.1"
+jtreesitter = "0.24.0"
 junit = "5.10.2"
 kotlin = "2.0.0"
 kotlinx = "1.7.1"

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -15,7 +15,6 @@
  */
 package org.pkl.lsp.ast
 
-import io.github.treesitter.jtreesitter.Node
 import java.net.URI
 import java.net.URLEncoder
 import kotlinx.serialization.json.add
@@ -433,12 +432,6 @@ fun PklNode.modificationTracker(): ModificationTracker = containingFile
 
 val PklNode.isInPackage: Boolean
   get() = containingFile.`package` != null
-
-fun Node.utfAwareText(): String {
-  val utf8 = Charsets.UTF_8
-  val text = tree.text ?: throw RuntimeException("Syntax tree has no source")
-  return String(text.toByteArray(utf8), startByte, endByte - startByte, utf8)
-}
 
 fun PklStringConstant.contentsSpan(): Span {
   val stringStart = terminals.first().span

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -717,7 +717,7 @@ abstract class AbstractPklNode(
 
   override val children: List<PklNode> by lazy { childrenByType.values.flatten() }
 
-  override val text: String by lazy { ctx.text ?: "" }
+  override val text: String by lazy { ctx.text }
 
   override val isMissing: Boolean by lazy { ctx.isMissing }
 

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -717,7 +717,7 @@ abstract class AbstractPklNode(
 
   override val children: List<PklNode> by lazy { childrenByType.values.flatten() }
 
-  override val text: String by lazy { ctx.utfAwareText() }
+  override val text: String by lazy { ctx.text ?: "" }
 
   override val isMissing: Boolean by lazy { ctx.isMissing }
 


### PR DESCRIPTION
This version fixes two problems where we had to make workarounds:

- `Node.getText()` was not encode-aware.
- `Tree`s were not allowed to be shared between threads.

This PR upgrades the version and removes the workarounds.