### PR TITLE
Tweak Gradle build

### DIFF
--- a/buildSrc/src/main/kotlin/BuildInfo.kt
+++ b/buildSrc/src/main/kotlin/BuildInfo.kt
@@ -33,6 +33,12 @@ open class BuildInfo(val project: Project) {
     OperatingSystem.current()
   }
 
+  /** The JDK version used to build the language server. */
+  val jdkVersion: Int = 22
+
+  /** The minimum JDK version required to run the language server. */
+  val jdkTargetVersion: Int = 22
+
   val arch: Architecture
     get() {
       return when (val arch = System.getProperty("os.arch")) {


### PR DESCRIPTION
    - fix IntelliJ errors in build.gradle.kts by declaring `buildInfo`
    - distinguish between jdkVersion and jdkTargetVersion and set them once in BuildInfo
      - it's often preferable to build with the latest JDK version even
        if targeting an older version
    - enforce jdkTargetVersion in compilation tasks
      - prevents accidental use of newer JDK APIs
    - run tests with `--enable-native-access=ALL-UNNAMED` to prevent warnings