### PR TITLE
Skip analyzing error nodes

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -747,6 +747,10 @@ class PklErrorImpl(
   override val parent: PklNode?,
   override val ctx: Node,
 ) : PklError, AbstractPklNode(project, parent, ctx) {
+  // don't bother analyzing error nodes any further
+  override val children: List<PklNode>
+    get() = listOf()
+
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitError(this)
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,6 +152,12 @@ fun Node.toTerminal(parent: PklNode): Terminal? {
       "identifier" -> TokenType.Identifier
       "docComment" -> TokenType.DocComment
       "escapeSequence" -> TokenType.CharacterEscape
+      "\\(" -> TokenType.InterpolationStart
+      "\\#(" -> TokenType.InterpolationStart
+      "\\##(" -> TokenType.InterpolationStart
+      "\\###(" -> TokenType.InterpolationStart
+      "\\####(" -> TokenType.InterpolationStart
+      "\\#####(" -> TokenType.InterpolationStart
       "\n" -> TokenType.Whitespace
       // TODO: see if we need these
       //      PklParser.NewlineSemicolon -> TokenType.NewlineSemicolon

--- a/src/main/kotlin/org/pkl/lsp/ast/TokenType.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/TokenType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -119,6 +119,7 @@ enum class TokenType {
   MLInterpolation,
   MLNewline,
   MLCharacters,
+  InterpolationStart,
 }
 
 val modifierTypes =


### PR DESCRIPTION
In tree-sitter, error nodes can possibly have children. However, these nodes aren't very meaningful to analyze, and can possibly cause unexpected exceptions when doing so.

Also: add interpolation start as a token type to be safe.

Closes https://github.com/apple/pkl-lsp/issues/64