### PR TITLE
Prevent stack overflow when computing types

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,12 @@
  */
 package org.pkl.lsp.type
 
-import java.util.IdentityHashMap
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitors
 import org.pkl.lsp.resolvers.Resolvers
-
-private val value = Any()
+import org.pkl.lsp.util.RecursionManager
 
 fun PklNode?.computeResolvedImportType(
   base: PklBaseModule,
@@ -30,163 +28,165 @@ fun PklNode?.computeResolvedImportType(
   context: PklProject?,
   preserveUnboundTypeVars: Boolean = false,
   canInferExprBody: Boolean = true,
-  cache: IdentityHashMap<PklNode, Any> = IdentityHashMap(),
 ): Type {
   if (this == null) return Type.Unknown
-  if (cache.containsKey(this)) return Type.Unknown
-  cache[this] = value
 
-  return when (this) {
-    is PklModule -> Type.module(this, shortDisplayName, context)
-    is PklClass -> Type.Class(this)
-    is PklTypeAlias -> Type.alias(this, context)
-    is PklMethod ->
-      when {
-        methodHeader.returnType != null ->
-          methodHeader.returnType.toType(base, bindings, context, preserveUnboundTypeVars)
-        else ->
+  return RecursionManager.doPreventingRecursion(this, "computeResolvedImportType", Type.Unknown) {
+    when (this) {
+      is PklModule -> Type.module(this, shortDisplayName, context)
+      is PklClass -> Type.Class(this)
+      is PklTypeAlias -> Type.alias(this, context)
+      is PklMethod ->
+        when {
+          methodHeader.returnType != null ->
+            methodHeader.returnType.toType(base, bindings, context, preserveUnboundTypeVars)
+          else ->
+            when {
+              canInferExprBody && !isOverridable -> body.computeExprType(base, bindings, context)
+              else -> Type.Unknown
+            }
+        }
+      is PklProperty ->
+        when {
+          type != null -> type.toType(base, bindings, context, preserveUnboundTypeVars)
+          else ->
+            when {
+              canInferExprBody && isLocalOrConstOrFixed ->
+                expr.computeExprType(base, bindings, context)
+              isDefinition -> Type.Unknown
+              else -> {
+                val receiverType = computeThisType(base, bindings, context)
+                val visitor =
+                  ResolveVisitors.typeOfFirstElementNamed(
+                    name,
+                    null,
+                    base,
+                    false,
+                    preserveUnboundTypeVars,
+                  )
+                Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor, context)
+              }
+            }
+        }
+      is PklMemberPredicate -> {
+        val receiverClassType =
+          computeThisType(base, bindings, context).toClassType(base, context)
+            ?: return@doPreventingRecursion Type.Unknown
+        val baseType =
           when {
-            canInferExprBody && !isOverridable -> body.computeExprType(base, bindings, context)
+            receiverClassType.classEquals(base.listingType) -> receiverClassType.typeArguments[0]
+            receiverClassType.classEquals(base.mappingType) -> receiverClassType.typeArguments[1]
             else -> Type.Unknown
           }
+        // flow typing support, e.g. `[[this is Person]] { ... }`
+        val cond = conditionExpr ?: return@doPreventingRecursion baseType
+        val visitor =
+          ResolveVisitors.typeOfFirstElementNamed(
+            "this",
+            null,
+            base,
+            isNullSafeAccess = false,
+            preserveUnboundTypeVars = false,
+          )
+        if (
+          Resolvers.visitSatisfiedCondition(cond, bindings, visitor, context) ||
+            visitor.result == Type.Unknown
+        )
+          baseType
+        else visitor.result
       }
-    is PklProperty ->
-      when {
-        type != null -> type.toType(base, bindings, context, preserveUnboundTypeVars)
-        else ->
-          when {
-            canInferExprBody && isLocalOrConstOrFixed ->
-              expr.computeExprType(base, bindings, context)
-            isDefinition -> Type.Unknown
-            else -> {
-              val receiverType = computeThisType(base, bindings, context)
-              val visitor =
-                ResolveVisitors.typeOfFirstElementNamed(
-                  name,
-                  null,
-                  base,
-                  false,
-                  preserveUnboundTypeVars,
-                )
-              Resolvers.resolveQualifiedAccess(receiverType, true, base, visitor, context)
-            }
-          }
-      }
-    is PklMemberPredicate -> {
-      val receiverClassType =
-        computeThisType(base, bindings, context).toClassType(base, context) ?: return Type.Unknown
-      val baseType =
+      is PklObjectEntry,
+      is PklObjectElement -> {
+        val receiverClassType =
+          computeThisType(base, bindings, context).toClassType(base, context)
+            ?: return@doPreventingRecursion Type.Unknown
         when {
           receiverClassType.classEquals(base.listingType) -> receiverClassType.typeArguments[0]
           receiverClassType.classEquals(base.mappingType) -> receiverClassType.typeArguments[1]
           else -> Type.Unknown
         }
-      // flow typing support, e.g. `[[this is Person]] { ... }`
-      val cond = conditionExpr ?: return baseType
-      val visitor =
-        ResolveVisitors.typeOfFirstElementNamed(
-          "this",
-          null,
-          base,
-          isNullSafeAccess = false,
-          preserveUnboundTypeVars = false,
-        )
-      if (
-        Resolvers.visitSatisfiedCondition(cond, bindings, visitor, context) ||
-          visitor.result == Type.Unknown
-      )
-        baseType
-      else visitor.result
-    }
-    is PklObjectEntry,
-    is PklObjectElement -> {
-      val receiverClassType =
-        computeThisType(base, bindings, context).toClassType(base, context) ?: return Type.Unknown
-      when {
-        receiverClassType.classEquals(base.listingType) -> receiverClassType.typeArguments[0]
-        receiverClassType.classEquals(base.mappingType) -> receiverClassType.typeArguments[1]
-        else -> Type.Unknown
       }
-    }
-    is PklTypedIdentifier ->
-      when {
-        type != null -> type.toType(base, bindings, context, preserveUnboundTypeVars)
-        else -> { // try to infer identifier type
-          when (val identifierOwner = parent) {
-            is PklLetExpr -> identifierOwner.varExpr.computeExprType(base, bindings, context)
-            is PklForGenerator -> {
-              val iterableType =
-                identifierOwner.iterableExpr.computeExprType(base, bindings, context)
-              val iterableClassType = iterableType.toClassType(base, context) ?: return Type.Unknown
-              val keyValueVars = identifierOwner.parameters
-              when {
-                keyValueVars.size > 1 && keyValueVars[0] == this -> {
-                  when {
-                    iterableClassType.classEquals(base.intSeqType) -> base.intType
-                    iterableClassType.classEquals(base.listType) ||
-                      iterableClassType.classEquals(base.setType) ||
-                      iterableClassType.classEquals(base.listingType) -> base.intType
-                    iterableClassType.classEquals(base.mapType) ||
-                      iterableClassType.classEquals(base.mappingType) ->
-                      iterableClassType.typeArguments[0]
-                    iterableClassType.isSubtypeOf(base.typedType, base, context) -> base.stringType
-                    else -> Type.Unknown
+      is PklTypedIdentifier ->
+        when {
+          type != null -> type.toType(base, bindings, context, preserveUnboundTypeVars)
+          else -> { // try to infer identifier type
+            when (val identifierOwner = parent) {
+              is PklLetExpr -> identifierOwner.varExpr.computeExprType(base, bindings, context)
+              is PklForGenerator -> {
+                val iterableType =
+                  identifierOwner.iterableExpr.computeExprType(base, bindings, context)
+                val iterableClassType =
+                  iterableType.toClassType(base, context)
+                    ?: return@doPreventingRecursion Type.Unknown
+                val keyValueVars = identifierOwner.parameters
+                when {
+                  keyValueVars.size > 1 && keyValueVars[0] == this -> {
+                    when {
+                      iterableClassType.classEquals(base.intSeqType) -> base.intType
+                      iterableClassType.classEquals(base.listType) ||
+                        iterableClassType.classEquals(base.setType) ||
+                        iterableClassType.classEquals(base.listingType) -> base.intType
+                      iterableClassType.classEquals(base.mapType) ||
+                        iterableClassType.classEquals(base.mappingType) ->
+                        iterableClassType.typeArguments[0]
+                      iterableClassType.isSubtypeOf(base.typedType, base, context) ->
+                        base.stringType
+                      else -> Type.Unknown
+                    }
                   }
-                }
-                else -> {
-                  when {
-                    iterableClassType.classEquals(base.intSeqType) -> base.intType
-                    iterableClassType.classEquals(base.listType) ||
-                      iterableClassType.classEquals(base.setType) ||
-                      iterableClassType.classEquals(base.listingType) ->
-                      iterableClassType.typeArguments[0]
-                    iterableClassType.classEquals(base.mapType) ||
-                      iterableClassType.classEquals(base.mappingType) ->
-                      iterableClassType.typeArguments[1]
-                    iterableClassType.isSubtypeOf(base.typedType, base, context) ->
-                      Type.Unknown // could strengthen value type to union of property types
-                    else -> Type.Unknown
+                  else -> {
+                    when {
+                      iterableClassType.classEquals(base.intSeqType) -> base.intType
+                      iterableClassType.classEquals(base.listType) ||
+                        iterableClassType.classEquals(base.setType) ||
+                        iterableClassType.classEquals(base.listingType) ->
+                        iterableClassType.typeArguments[0]
+                      iterableClassType.classEquals(base.mapType) ||
+                        iterableClassType.classEquals(base.mappingType) ->
+                        iterableClassType.typeArguments[1]
+                      iterableClassType.isSubtypeOf(base.typedType, base, context) ->
+                        Type.Unknown // could strengthen value type to union of property types
+                      else -> Type.Unknown
+                    }
                   }
                 }
               }
-            }
-            is PklParameterList -> {
-              when (val parameterListOwner = identifierOwner.parent) {
-                is PklFunctionLiteralExpr -> {
-                  val functionType =
-                    parameterListOwner.inferExprTypeFromContext(base, bindings, context)
-                  getFunctionParameterType(this, identifierOwner, functionType, base, context)
-                }
-                is PklObjectBody ->
-                  when (val objectBodyOwner = parameterListOwner.parent) {
-                    is PklExpr -> {
-                      val functionType = objectBodyOwner.computeExprType(base, bindings, context)
-                      getFunctionParameterType(this, identifierOwner, functionType, base, context)
-                    }
-                    is PklObjectBodyOwner -> {
-                      @Suppress("BooleanLiteralArgument")
-                      val functionType =
-                        objectBodyOwner.computeResolvedImportType(
-                          base,
-                          bindings,
-                          context,
-                          false,
-                          false,
-                          cache,
-                        )
-                      getFunctionParameterType(this, identifierOwner, functionType, base, context)
-                    }
-                    else -> Type.Unknown
+              is PklParameterList -> {
+                when (val parameterListOwner = identifierOwner.parent) {
+                  is PklFunctionLiteralExpr -> {
+                    val functionType =
+                      parameterListOwner.inferExprTypeFromContext(base, bindings, context)
+                    getFunctionParameterType(this, identifierOwner, functionType, base, context)
                   }
-                else -> Type.Unknown
+                  is PklObjectBody ->
+                    when (val objectBodyOwner = parameterListOwner.parent) {
+                      is PklExpr -> {
+                        val functionType = objectBodyOwner.computeExprType(base, bindings, context)
+                        getFunctionParameterType(this, identifierOwner, functionType, base, context)
+                      }
+                      is PklObjectBodyOwner -> {
+                        @Suppress("BooleanLiteralArgument")
+                        val functionType =
+                          objectBodyOwner.computeResolvedImportType(
+                            base,
+                            bindings,
+                            context,
+                            canInferExprBody = false,
+                          )
+                        getFunctionParameterType(this, identifierOwner, functionType, base, context)
+                      }
+                      else -> Type.Unknown
+                    }
+                  else -> Type.Unknown
+                }
               }
+              else -> Type.Unknown
             }
-            else -> Type.Unknown
           }
         }
-      }
-    is PklTypeParameter -> Type.Unknown
-    else -> Type.Unknown
+      is PklTypeParameter -> Type.Unknown
+      else -> Type.Unknown
+    }
   }
 }
 

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
@@ -15,13 +15,11 @@
  */
 package org.pkl.lsp.type
 
-import java.util.*
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.resolvers.ResolveVisitors
-
-private val cache: IdentityHashMap<PklNode, Type> = IdentityHashMap()
+import org.pkl.lsp.util.RecursionManager
 
 fun PklNode?.computeExprType(
   base: PklBaseModule,
@@ -30,16 +28,11 @@ fun PklNode?.computeExprType(
 ): Type {
   return when {
     this == null || this !is PklExpr -> Type.Unknown
-    // TODO: properly invalidate the cache
     //    bindings.isEmpty() -> {
-    //      val type = cache[this]
-    //      if (type != null) {
-    //        type
-    //      } else {
-    //        val typ = doComputeExprType(base, bindings)
-    //        cache[this] = typ
-    //        typ
-    //      }
+    //      project.cachedValuesManager.getCachedValue("computeExprType") {
+    //        val result = doComputeExprType(base, bindings, context)
+    //        CachedValue(result)
+    //      }!!
     //    }
     else -> doComputeExprType(base, bindings, context)
   }
@@ -50,334 +43,338 @@ private fun PklNode.doComputeExprType(
   bindings: TypeParameterBindings,
   context: PklProject?,
 ): Type {
-  return when (this) {
-    is PklUnqualifiedAccessExpr -> {
-      val visitor =
-        ResolveVisitors.typeOfFirstElementNamed(
-          memberNameText,
-          argumentList,
-          base,
-          isNullSafeAccess,
-          false,
-        )
-      resolve(base, null, bindings, visitor, context)
-    }
-    is PklQualifiedAccessExpr -> {
-      val visitor =
-        ResolveVisitors.typeOfFirstElementNamed(
-          memberNameText,
-          argumentList,
-          base,
-          isNullSafeAccess,
-          false,
-        )
-      resolve(base, null, bindings, visitor, context)
-    }
-    is PklSuperAccessExpr -> {
-      val visitor =
-        ResolveVisitors.typeOfFirstElementNamed(
-          memberNameText,
-          argumentList,
-          base,
-          isNullSafeAccess,
-          false,
-        )
-      resolve(base, null, bindings, visitor, context)
-    }
-    is PklTrueLiteralExpr,
-    is PklFalseLiteralExpr -> base.booleanType
-    is PklSingleLineStringLiteral -> {
-      val unescaped = escapedText()
-      if (unescaped == null) base.stringType else Type.StringLiteral(unescaped)
-    }
-    is PklMultiLineStringLiteral -> {
-      val unescaped = escapedText()
-      if (unescaped == null) base.stringType else Type.StringLiteral(unescaped)
-    }
-    is PklNullLiteralExpr -> base.nullType
-    is PklIntLiteralExpr -> base.intType
-    is PklFloatLiteralExpr -> base.floatType
+  return RecursionManager.doPreventingRecursion(this, "doComputeExprType", Type.Unknown) {
+    when (this) {
+      is PklUnqualifiedAccessExpr -> {
+        val visitor =
+          ResolveVisitors.typeOfFirstElementNamed(
+            memberNameText,
+            argumentList,
+            base,
+            isNullSafeAccess,
+            false,
+          )
+        resolve(base, null, bindings, visitor, context)
+      }
+      is PklQualifiedAccessExpr -> {
+        val visitor =
+          ResolveVisitors.typeOfFirstElementNamed(
+            memberNameText,
+            argumentList,
+            base,
+            isNullSafeAccess,
+            false,
+          )
+        resolve(base, null, bindings, visitor, context)
+      }
+      is PklSuperAccessExpr -> {
+        val visitor =
+          ResolveVisitors.typeOfFirstElementNamed(
+            memberNameText,
+            argumentList,
+            base,
+            isNullSafeAccess,
+            false,
+          )
+        resolve(base, null, bindings, visitor, context)
+      }
+      is PklTrueLiteralExpr,
+      is PklFalseLiteralExpr -> base.booleanType
+      is PklSingleLineStringLiteral -> {
+        val unescaped = escapedText()
+        if (unescaped == null) base.stringType else Type.StringLiteral(unescaped)
+      }
+      is PklMultiLineStringLiteral -> {
+        val unescaped = escapedText()
+        if (unescaped == null) base.stringType else Type.StringLiteral(unescaped)
+      }
+      is PklNullLiteralExpr -> base.nullType
+      is PklIntLiteralExpr -> base.intType
+      is PklFloatLiteralExpr -> base.floatType
 
-    // inferring Listing/Mapping type parameters from elements/entries is tricky
-    // because the latter are in turn inferred from Listing/Mapping types (e.g., in PklNewExpr)
-    is PklAmendExpr -> parentExpr.computeExprType(base, bindings, context).amended(base, context)
-    is PklNewExpr ->
-      (type?.toType(base, bindings, context) ?: inferExprTypeFromContext(base, bindings, context))
-        .instantiated(base, context)
-    is PklThisExpr -> computeThisType(base, bindings, context)
-    is PklOuterExpr -> Type.Unknown // TODO
-    is PklSubscriptExpr -> {
-      val receiverType = leftExpr.computeExprType(base, bindings, context)
-      doComputeSubscriptExprType(receiverType, base, context)
-    }
-    is PklSuperSubscriptExpr -> {
-      val receiverType = computeThisType(base, bindings, context)
-      doComputeSubscriptExprType(receiverType, base, context)
-    }
-    is PklEqualityExpr -> base.booleanType
-    is PklComparisonExpr -> base.booleanType
-    is PklLogicalAndExpr -> base.booleanType
-    is PklLogicalOrExpr -> base.booleanType
-    is PklLogicalNotExpr -> base.booleanType
-    is PklTypeTestExpr -> base.booleanType
-    is PklTypeCastExpr -> type.toType(base, bindings, context)
-    is PklModuleExpr ->
-      enclosingModule?.computeResolvedImportType(base, mapOf(), context) ?: Type.Unknown
-    is PklUnaryMinusExpr -> {
-      when (expr.computeExprType(base, bindings, context)) {
-        base.intType -> base.intType
-        base.booleanType -> base.booleanType
-        else -> Type.Unknown
+      // inferring Listing/Mapping type parameters from elements/entries is tricky
+      // because the latter are in turn inferred from Listing/Mapping types (e.g., in PklNewExpr)
+      is PklAmendExpr -> parentExpr.computeExprType(base, bindings, context).amended(base, context)
+      is PklNewExpr ->
+        (type?.toType(base, bindings, context) ?: inferExprTypeFromContext(base, bindings, context))
+          .instantiated(base, context)
+      is PklThisExpr -> computeThisType(base, bindings, context)
+      is PklOuterExpr -> Type.Unknown // TODO
+      is PklSubscriptExpr -> {
+        val receiverType = leftExpr.computeExprType(base, bindings, context)
+        doComputeSubscriptExprType(receiverType, base, context)
       }
-    }
-    is PklAdditiveExpr -> {
-      val leftType = leftExpr.computeExprType(base, bindings, context)
-      val rightType = rightExpr.computeExprType(base, bindings, context)
-      val op = operator.type
-      when (leftType) {
-        base.intType ->
-          when (rightType) {
-            base.intType -> base.intType
-            base.booleanType -> base.booleanType
-            else -> Type.Unknown
-          }
-        base.floatType ->
-          when (rightType) {
-            base.intType,
-            base.floatType -> base.floatType
-            else -> Type.Unknown
-          }
-        base.stringType ->
-          if (op == TokenType.PLUS) {
+      is PklSuperSubscriptExpr -> {
+        val receiverType = computeThisType(base, bindings, context)
+        doComputeSubscriptExprType(receiverType, base, context)
+      }
+      is PklEqualityExpr -> base.booleanType
+      is PklComparisonExpr -> base.booleanType
+      is PklLogicalAndExpr -> base.booleanType
+      is PklLogicalOrExpr -> base.booleanType
+      is PklLogicalNotExpr -> base.booleanType
+      is PklTypeTestExpr -> base.booleanType
+      is PklTypeCastExpr -> type.toType(base, bindings, context)
+      is PklModuleExpr ->
+        enclosingModule?.computeResolvedImportType(base, mapOf(), context) ?: Type.Unknown
+      is PklUnaryMinusExpr -> {
+        when (expr.computeExprType(base, bindings, context)) {
+          base.intType -> base.intType
+          base.booleanType -> base.booleanType
+          else -> Type.Unknown
+        }
+      }
+      is PklAdditiveExpr -> {
+        val leftType = leftExpr.computeExprType(base, bindings, context)
+        val rightType = rightExpr.computeExprType(base, bindings, context)
+        val op = operator.type
+        when (leftType) {
+          base.intType ->
             when (rightType) {
-              base.stringType,
-              is Type.StringLiteral -> base.stringType
+              base.intType -> base.intType
+              base.booleanType -> base.booleanType
               else -> Type.Unknown
             }
-          } else Type.Unknown
-        is Type.StringLiteral ->
-          if (op == TokenType.PLUS) {
+          base.floatType ->
             when (rightType) {
-              base.stringType -> base.stringType
-              is Type.StringLiteral -> Type.StringLiteral(leftType.value + rightType.value)
+              base.intType,
+              base.floatType -> base.floatType
               else -> Type.Unknown
             }
-          } else Type.Unknown
-        Type.Unknown ->
-          // could be more aggressive here and try to infer the result type from the right type
-          // (e.g., unknown + float = float)
-          Type.Unknown
-        else -> {
-          val leftClassType = leftType.toClassType(base, context) ?: return Type.Unknown
-          val rightClassType = rightType.toClassType(base, context) ?: return Type.Unknown
-          when {
-            leftClassType.classEquals(base.listType) ->
-              if (op == TokenType.PLUS) {
-                when {
-                  rightClassType.classEquals(base.listType) ||
-                    rightClassType.classEquals(base.setType) -> {
-                    val typeArgs =
-                      Type.union(
-                        leftClassType.typeArguments[0],
-                        rightClassType.typeArguments[0],
-                        base,
-                        context,
-                      )
-                    base.listType.withTypeArguments(typeArgs)
+          base.stringType ->
+            if (op == TokenType.PLUS) {
+              when (rightType) {
+                base.stringType,
+                is Type.StringLiteral -> base.stringType
+                else -> Type.Unknown
+              }
+            } else Type.Unknown
+          is Type.StringLiteral ->
+            if (op == TokenType.PLUS) {
+              when (rightType) {
+                base.stringType -> base.stringType
+                is Type.StringLiteral -> Type.StringLiteral(leftType.value + rightType.value)
+                else -> Type.Unknown
+              }
+            } else Type.Unknown
+          Type.Unknown ->
+            // could be more aggressive here and try to infer the result type from the right type
+            // (e.g., unknown + float = float)
+            Type.Unknown
+          else -> {
+            val leftClassType =
+              leftType.toClassType(base, context) ?: return@doPreventingRecursion Type.Unknown
+            val rightClassType =
+              rightType.toClassType(base, context) ?: return@doPreventingRecursion Type.Unknown
+            when {
+              leftClassType.classEquals(base.listType) ->
+                if (op == TokenType.PLUS) {
+                  when {
+                    rightClassType.classEquals(base.listType) ||
+                      rightClassType.classEquals(base.setType) -> {
+                      val typeArgs =
+                        Type.union(
+                          leftClassType.typeArguments[0],
+                          rightClassType.typeArguments[0],
+                          base,
+                          context,
+                        )
+                      base.listType.withTypeArguments(typeArgs)
+                    }
+                    else -> Type.Unknown
                   }
-                  else -> Type.Unknown
-                }
-              } else Type.Unknown
-            leftClassType.classEquals(base.setType) ->
-              if (op == TokenType.PLUS) {
-                when {
-                  rightClassType.classEquals(base.listType) ||
-                    rightClassType.classEquals(base.setType) -> {
-                    val typeArgs =
-                      Type.union(
-                        leftClassType.typeArguments[0],
-                        rightClassType.typeArguments[0],
-                        base,
-                        context,
-                      )
-                    base.setType.withTypeArguments(typeArgs)
+                } else Type.Unknown
+              leftClassType.classEquals(base.setType) ->
+                if (op == TokenType.PLUS) {
+                  when {
+                    rightClassType.classEquals(base.listType) ||
+                      rightClassType.classEquals(base.setType) -> {
+                      val typeArgs =
+                        Type.union(
+                          leftClassType.typeArguments[0],
+                          rightClassType.typeArguments[0],
+                          base,
+                          context,
+                        )
+                      base.setType.withTypeArguments(typeArgs)
+                    }
+                    else -> Type.Unknown
                   }
-                  else -> Type.Unknown
-                }
-              } else Type.Unknown
-            leftClassType.classEquals(base.mapType) ->
-              if (op == TokenType.PLUS) {
-                when {
-                  rightClassType.classEquals(base.mapType) -> {
-                    val keyTypeArgs =
-                      Type.union(
-                        leftClassType.typeArguments[0],
-                        rightClassType.typeArguments[0],
-                        base,
-                        context,
-                      )
-                    val valueTypeArgs =
-                      Type.union(
-                        leftClassType.typeArguments[1],
-                        rightClassType.typeArguments[1],
-                        base,
-                        context,
-                      )
-                    base.mapType.withTypeArguments(keyTypeArgs, valueTypeArgs)
+                } else Type.Unknown
+              leftClassType.classEquals(base.mapType) ->
+                if (op == TokenType.PLUS) {
+                  when {
+                    rightClassType.classEquals(base.mapType) -> {
+                      val keyTypeArgs =
+                        Type.union(
+                          leftClassType.typeArguments[0],
+                          rightClassType.typeArguments[0],
+                          base,
+                          context,
+                        )
+                      val valueTypeArgs =
+                        Type.union(
+                          leftClassType.typeArguments[1],
+                          rightClassType.typeArguments[1],
+                          base,
+                          context,
+                        )
+                      base.mapType.withTypeArguments(keyTypeArgs, valueTypeArgs)
+                    }
+                    else -> Type.Unknown
                   }
-                  else -> Type.Unknown
-                }
-              } else Type.Unknown
-            else -> Type.Unknown
-          }
-        }
-      }
-    }
-    is PklMultiplicativeExpr -> {
-      val leftType = leftExpr.computeExprType(base, bindings, context)
-      val rightType = rightExpr.computeExprType(base, bindings, context)
-      when (operator.type) {
-        TokenType.STAR ->
-          when (leftType) {
-            base.intType ->
-              when (rightType) {
-                base.intType -> base.intType
-                base.floatType -> base.floatType
-                else -> Type.Unknown
-              }
-            base.floatType ->
-              when (rightType) {
-                base.intType,
-                base.floatType,
-                Type.Unknown -> base.floatType
-                else -> Type.Unknown
-              }
-            Type.Unknown -> {
-              when (rightType) {
-                base.floatType -> base.floatType
-                else -> Type.Unknown
-              }
-            }
-            else -> Type.Unknown
-          }
-        TokenType.DIV ->
-          when (leftType) {
-            base.intType,
-            base.floatType,
-            Type.Unknown ->
-              when (rightType) {
-                base.intType,
-                base.floatType,
-                Type.Unknown -> base.floatType
-                else -> Type.Unknown
-              }
-            else -> Type.Unknown
-          }
-        TokenType.INT_DIV ->
-          when (leftType) {
-            base.intType,
-            base.floatType,
-            Type.Unknown ->
-              when (rightType) {
-                base.intType,
-                base.floatType,
-                Type.Unknown -> base.intType
-                else -> Type.Unknown
-              }
-            else -> Type.Unknown
-          }
-        TokenType.MOD ->
-          when (leftType) {
-            base.intType ->
-              when (rightType) {
-                base.intType -> base.intType
-                base.floatType -> base.floatType
-                else -> Type.Unknown
-              }
-            base.floatType ->
-              when (rightType) {
-                base.intType,
-                base.floatType,
-                Type.Unknown -> base.floatType
-                else -> Type.Unknown
-              }
-            Type.Unknown ->
-              when (rightType) {
-                base.floatType -> base.floatType
-                else -> Type.Unknown
-              }
-            else -> Type.Unknown
-          }
-        else -> {
-          // rdar://74188588 (not sure how this can happen)
-          // logger.error("Unexpected multiplicative operator: ${operator.elementType}")
-          Type.Unknown
-        }
-      }
-    }
-    is PklExponentiationExpr -> base.numberType
-    is PklLetExpr -> bodyExpr.computeExprType(base, bindings, context)
-    is PklThrowExpr -> Type.Nothing
-    is PklTraceExpr -> expr.computeExprType(base, bindings, context)
-    is PklImportExpr -> resolve(context).computeResolvedImportType(base, mapOf(), false, context)
-    is PklReadExpr -> {
-      val result =
-        when (val resourceUriExpr = expr) {
-          is PklSingleLineStringLiteral -> inferResourceType(resourceUriExpr, base, context)
-          // support `read("env:" + ...)`
-          is PklAdditiveExpr -> {
-            when (val leftExpr = resourceUriExpr.leftExpr) {
-              is PklSingleLineStringLiteral -> inferResourceType(leftExpr, base, context)
-              else -> Type.union(base.stringType, base.resourceType, base, context)
+                } else Type.Unknown
+              else -> Type.Unknown
             }
           }
-          else -> Type.union(base.stringType, base.resourceType, base, context)
         }
-      if (isNullable) result.nullable(base, context)
-      else if (isGlob) base.mappingType.withTypeArguments(base.stringType, result) else result
-    }
-    is PklIfExpr ->
-      Type.union(
-        thenExpr.computeExprType(base, bindings, context),
-        elseExpr.computeExprType(base, bindings, context),
-        base,
-        context,
-      )
-    is PklNullCoalesceExpr ->
-      Type.union(
-        leftExpr.computeExprType(base, bindings, context).nonNull(base, context),
-        rightExpr.computeExprType(base, bindings, context),
-        base,
-        context,
-      )
-    is PklNonNullExpr -> expr.computeExprType(base, bindings, context).nonNull(base, context)
-    is PklPipeExpr -> {
-      val rightType = rightExpr.computeExprType(base, bindings, context)
-      val classType = rightType.toClassType(base, context)
-      when {
-        classType != null && classType.isFunctionType -> classType.typeArguments.last()
-        rightType == Type.Unknown -> Type.Unknown
-        else -> Type.Unknown
       }
-    }
-    is PklFunctionLiteralExpr -> {
-      val parameterTypes = parameterList.elements.map { it.type.toType(base, bindings, context) }
-      val returnType = expr.computeExprType(base, bindings, context)
-      when (parameterTypes.size) {
-        0 -> base.function0Type.withTypeArguments(parameterTypes + returnType)
-        1 -> base.function1Type.withTypeArguments(parameterTypes + returnType)
-        2 -> base.function2Type.withTypeArguments(parameterTypes + returnType)
-        3 -> base.function3Type.withTypeArguments(parameterTypes + returnType)
-        4 -> base.function4Type.withTypeArguments(parameterTypes + returnType)
-        5 -> base.function5Type.withTypeArguments(parameterTypes + returnType)
-        else ->
-          base.functionType.withTypeArguments(
-            listOf(returnType)
-          ) // approximation (invalid Pkl code)
+      is PklMultiplicativeExpr -> {
+        val leftType = leftExpr.computeExprType(base, bindings, context)
+        val rightType = rightExpr.computeExprType(base, bindings, context)
+        when (operator.type) {
+          TokenType.STAR ->
+            when (leftType) {
+              base.intType ->
+                when (rightType) {
+                  base.intType -> base.intType
+                  base.floatType -> base.floatType
+                  else -> Type.Unknown
+                }
+              base.floatType ->
+                when (rightType) {
+                  base.intType,
+                  base.floatType,
+                  Type.Unknown -> base.floatType
+                  else -> Type.Unknown
+                }
+              Type.Unknown -> {
+                when (rightType) {
+                  base.floatType -> base.floatType
+                  else -> Type.Unknown
+                }
+              }
+              else -> Type.Unknown
+            }
+          TokenType.DIV ->
+            when (leftType) {
+              base.intType,
+              base.floatType,
+              Type.Unknown ->
+                when (rightType) {
+                  base.intType,
+                  base.floatType,
+                  Type.Unknown -> base.floatType
+                  else -> Type.Unknown
+                }
+              else -> Type.Unknown
+            }
+          TokenType.INT_DIV ->
+            when (leftType) {
+              base.intType,
+              base.floatType,
+              Type.Unknown ->
+                when (rightType) {
+                  base.intType,
+                  base.floatType,
+                  Type.Unknown -> base.intType
+                  else -> Type.Unknown
+                }
+              else -> Type.Unknown
+            }
+          TokenType.MOD ->
+            when (leftType) {
+              base.intType ->
+                when (rightType) {
+                  base.intType -> base.intType
+                  base.floatType -> base.floatType
+                  else -> Type.Unknown
+                }
+              base.floatType ->
+                when (rightType) {
+                  base.intType,
+                  base.floatType,
+                  Type.Unknown -> base.floatType
+                  else -> Type.Unknown
+                }
+              Type.Unknown ->
+                when (rightType) {
+                  base.floatType -> base.floatType
+                  else -> Type.Unknown
+                }
+              else -> Type.Unknown
+            }
+          else -> {
+            // rdar://74188588 (not sure how this can happen)
+            // logger.error("Unexpected multiplicative operator: ${operator.elementType}")
+            Type.Unknown
+          }
+        }
       }
+      is PklExponentiationExpr -> base.numberType
+      is PklLetExpr -> bodyExpr.computeExprType(base, bindings, context)
+      is PklThrowExpr -> Type.Nothing
+      is PklTraceExpr -> expr.computeExprType(base, bindings, context)
+      is PklImportExpr -> resolve(context).computeResolvedImportType(base, mapOf(), false, context)
+      is PklReadExpr -> {
+        val result =
+          when (val resourceUriExpr = expr) {
+            is PklSingleLineStringLiteral -> inferResourceType(resourceUriExpr, base, context)
+            // support `read("env:" + ...)`
+            is PklAdditiveExpr -> {
+              when (val leftExpr = resourceUriExpr.leftExpr) {
+                is PklSingleLineStringLiteral -> inferResourceType(leftExpr, base, context)
+                else -> Type.union(base.stringType, base.resourceType, base, context)
+              }
+            }
+            else -> Type.union(base.stringType, base.resourceType, base, context)
+          }
+        if (isNullable) result.nullable(base, context)
+        else if (isGlob) base.mappingType.withTypeArguments(base.stringType, result) else result
+      }
+      is PklIfExpr ->
+        Type.union(
+          thenExpr.computeExprType(base, bindings, context),
+          elseExpr.computeExprType(base, bindings, context),
+          base,
+          context,
+        )
+      is PklNullCoalesceExpr ->
+        Type.union(
+          leftExpr.computeExprType(base, bindings, context).nonNull(base, context),
+          rightExpr.computeExprType(base, bindings, context),
+          base,
+          context,
+        )
+      is PklNonNullExpr -> expr.computeExprType(base, bindings, context).nonNull(base, context)
+      is PklPipeExpr -> {
+        val rightType = rightExpr.computeExprType(base, bindings, context)
+        val classType = rightType.toClassType(base, context)
+        when {
+          classType != null && classType.isFunctionType -> classType.typeArguments.last()
+          rightType == Type.Unknown -> Type.Unknown
+          else -> Type.Unknown
+        }
+      }
+      is PklFunctionLiteralExpr -> {
+        val parameterTypes = parameterList.elements.map { it.type.toType(base, bindings, context) }
+        val returnType = expr.computeExprType(base, bindings, context)
+        when (parameterTypes.size) {
+          0 -> base.function0Type.withTypeArguments(parameterTypes + returnType)
+          1 -> base.function1Type.withTypeArguments(parameterTypes + returnType)
+          2 -> base.function2Type.withTypeArguments(parameterTypes + returnType)
+          3 -> base.function3Type.withTypeArguments(parameterTypes + returnType)
+          4 -> base.function4Type.withTypeArguments(parameterTypes + returnType)
+          5 -> base.function5Type.withTypeArguments(parameterTypes + returnType)
+          else ->
+            base.functionType.withTypeArguments(
+              listOf(returnType)
+            ) // approximation (invalid Pkl code)
+        }
+      }
+      is PklParenthesizedExpr -> expr.computeExprType(base, bindings, context)
+      else -> Type.Unknown
     }
-    is PklParenthesizedExpr -> expr.computeExprType(base, bindings, context)
-    else -> Type.Unknown
   }
 }
 

--- a/src/main/kotlin/org/pkl/lsp/util/RecursionManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/RecursionManager.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.util
+
+import java.util.Collections
+import java.util.IdentityHashMap
+
+object RecursionManager {
+
+  private val recursionState: ThreadLocal<MutableMap<String, MutableSet<Any>>> =
+    ThreadLocal.withInitial(::mutableMapOf)
+
+  fun <T> doPreventingRecursion(key: Any, methodName: String, default: T, compute: () -> T): T {
+    val myState = recursionState.get()
+    val seenKeys =
+      myState[methodName]
+        ?: Collections.newSetFromMap(IdentityHashMap<Any, Boolean>()).also { state ->
+          myState[methodName] = state
+        }
+    if (seenKeys.contains(key)) {
+      return default
+    }
+    seenKeys.add(key)
+    try {
+      return compute().also {
+        seenKeys.remove(key)
+        if (seenKeys.isEmpty()) {
+          myState.remove(methodName)
+        }
+      }
+    } catch (e: Throwable) {
+      // prevent memory leak; clean up state on any exception
+      myState.remove(methodName)
+      throw e
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/util/RecursionManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/RecursionManager.kt
@@ -35,16 +35,16 @@ object RecursionManager {
     }
     seenKeys.add(key)
     try {
-      return compute().also {
-        seenKeys.remove(key)
-        if (seenKeys.isEmpty()) {
-          myState.remove(methodName)
-        }
-      }
+      return compute()
     } catch (e: Throwable) {
       // prevent memory leak; clean up state on any exception
       myState.remove(methodName)
       throw e
+    } finally {
+      seenKeys.remove(key)
+      if (seenKeys.isEmpty()) {
+        myState.remove(methodName)
+      }
     }
   }
 }

--- a/src/test/kotlin/org/pkl/lsp/HoverTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/HoverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,5 +83,37 @@ class HoverTest : LspTestBase() {
     assertThat(hoverText).contains("`true`")
     assertThat(hoverText).contains("`false`")
     assertThat(hoverText).contains("`null`")
+  }
+
+  @Test
+  fun `compute type for recursive method`() {
+    createPklFile(
+      """
+        function fi<caret>b(num: UInt) =
+          if (num == 0) 0
+          else if (num <= 2) 1
+          else fib(num - 1) + fib(num - 2)
+      """
+        .trimIndent()
+    )
+    val hoverText = getHoverText()
+    assertThat(hoverText).contains("function fib(num: UInt): unknown")
+  }
+
+  @Test
+  fun `compute type that depends on recursive method`() {
+    createPklFile(
+      """
+        function fib(num: UInt) =
+          if (num == 0) 0
+          else if (num <= 2) 1
+          else fib(num - 1) + fib(num - 2)
+          
+        local res<caret> = fib(5)
+      """
+        .trimIndent()
+    )
+    val hoverText = getHoverText()
+    assertThat(hoverText).contains("local res: unknown")
   }
 }


### PR DESCRIPTION
This prevents stack overflows from occurring when analyzing recursive methods, for example.

Loosely copies `RecursionManager` from the IntelliJ SDK

Closes https://github.com/apple/pkl-lsp/issues/46