### PR TITLE
Warning suppression

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
@@ -406,4 +406,12 @@ open class PklVisitor<R> {
   open fun visitDocCommentOwner(o: PklDocCommentOwner): R? {
     return visitElement(o)
   }
+
+  open fun visitLineComment(o: PklLineComment): R? {
+    return null
+  }
+
+  open fun visitBlockComment(o: PklBlockComment): R? {
+    return null
+  }
 }

--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -94,6 +94,8 @@ interface VirtualFile : ModificationTracker, CachedValueDataHolder {
   fun resolve(path: String): VirtualFile?
 
   fun getModule(): CompletableFuture<PklModule?>
+
+  fun canModify(): Boolean
 }
 
 sealed class BaseFile : VirtualFile, CachedValueDataHolderBase() {
@@ -194,6 +196,8 @@ class FsFile(override val path: Path, override val project: Project) : BaseFile(
     else null
   }
 
+  override fun canModify(): Boolean = true
+
   override fun doReadContents(): String = path.readText()
 }
 
@@ -224,6 +228,8 @@ class StdlibFile(moduleName: String, override val project: Project) : BaseFile()
       reader.readText()
     }
   }
+
+  override fun canModify(): Boolean = false
 }
 
 class HttpsFile(override val uri: URI, override val project: Project) : BaseFile() {
@@ -259,6 +265,8 @@ class HttpsFile(override val uri: URI, override val project: Project) : BaseFile
       uri.toURL().readText()
     }
   }
+
+  override fun canModify(): Boolean = false
 }
 
 class JarFile(override val path: Path, override val uri: URI, override val project: Project) :
@@ -302,6 +310,8 @@ class JarFile(override val path: Path, override val uri: URI, override val proje
     project.cachedValuesManager.getCachedValue(this, "${javaClass.simpleName}-contents-${uri}") {
       CachedValue(path.readText())
     }!!
+
+  override fun canModify(): Boolean = false
 }
 
 class EphemeralFile(private val text: String, override val project: Project) : BaseFile() {
@@ -322,4 +332,6 @@ class EphemeralFile(private val text: String, override val project: Project) : B
   override fun resolve(path: String): VirtualFile? = null
 
   override fun doReadContents(): String = text
+
+  override fun canModify(): Boolean = false
 }

--- a/src/main/kotlin/org/pkl/lsp/actions/PklCodeAction.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklCodeAction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,6 @@ package org.pkl.lsp.actions
 import org.eclipse.lsp4j.CodeAction
 import org.eclipse.lsp4j.CodeActionDisabled
 import org.eclipse.lsp4j.Command
-import org.pkl.lsp.Component
-import org.pkl.lsp.Project
 import org.pkl.lsp.analyzers.PklDiagnostic
 
 sealed interface PklCodeAction {
@@ -27,17 +25,9 @@ sealed interface PklCodeAction {
 
   val kind: String
 
-  val commandId: String
-
-  val arguments: List<Any>
-
   val disabled: CodeActionDisabled?
 
-  fun toMessage(diagnostic: PklDiagnostic): CodeAction
-}
-
-abstract class PklCommandCodeAction(project: Project) : Component(project), PklCodeAction {
-  final override fun toMessage(diagnostic: PklDiagnostic): CodeAction {
+  fun toMessage(diagnostic: PklDiagnostic): CodeAction {
     val self = this
     return CodeAction().apply {
       title = self.title
@@ -45,6 +35,15 @@ abstract class PklCommandCodeAction(project: Project) : Component(project), PklC
       disabled = self.disabled
       isPreferred = true
       diagnostics = listOf(diagnostic.toMessage())
+    }
+  }
+}
+
+abstract class PklCommandCodeAction(val commandId: String, val arguments: List<Any>) :
+  PklCodeAction {
+  final override fun toMessage(diagnostic: PklDiagnostic): CodeAction {
+    val self = this
+    return super.toMessage(diagnostic).apply {
       command =
         Command().apply {
           title = self.title

--- a/src/main/kotlin/org/pkl/lsp/actions/PklDownloadPackageAction.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklDownloadPackageAction.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,14 +22,10 @@ import org.pkl.lsp.Project
 import org.pkl.lsp.packages.dto.PackageUri
 
 class PklDownloadPackageAction(project: Project, packageUri: PackageUri) :
-  PklCommandCodeAction(project) {
+  PklCommandCodeAction("pkl.downloadPackage", listOf(packageUri.toString())) {
   override val title: String = "download package `${packageUri}"
 
   override val kind: String = CodeActionKind.QuickFix
-
-  override val commandId: String = "pkl.downloadPackage"
-
-  override val arguments: List<Any> = listOf(packageUri.toString())
 
   override val disabled: CodeActionDisabled? =
     if (project.pklCli.isUnavailable)

--- a/src/main/kotlin/org/pkl/lsp/actions/PklSuppressWarningsCodeAction.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklSuppressWarningsCodeAction.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.actions
+
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.CodeActionDisabled
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.pkl.lsp.LspUtil.toRange
+import org.pkl.lsp.analyzers.PklDiagnostic
+import org.pkl.lsp.analyzers.PklDiagnostic.Companion.getSuppression
+import org.pkl.lsp.analyzers.PklProblemGroup
+import org.pkl.lsp.ast.IdentifierOwner
+import org.pkl.lsp.ast.PklSuppressWarningsTarget
+import org.pkl.lsp.ast.Span
+import org.pkl.lsp.ast.lspUri
+
+class PklSuppressWarningsCodeAction(
+  private val node: PklSuppressWarningsTarget,
+  private val group: PklProblemGroup,
+) : PklCodeAction {
+  override val title: String
+    get() =
+      if (node is IdentifierOwner && node.identifier != null)
+        "Suppress '${group.problemName}' for ${node.getKind()} '${node.identifier!!.text}'"
+      else "Suppress '${group.problemName}' for ${node.getKind()}"
+
+  override val kind: String = CodeActionKind.QuickFix
+
+  // no need to set this if suppressed; we simply don't emit a diagnostic in that case.
+  override val disabled: CodeActionDisabled? = null
+
+  private fun addToExistingSuppression(suppression: PklDiagnostic.Companion.Suppression): TextEdit {
+    return TextEdit().apply {
+      range = suppression.lineComment.span.toRange()
+      newText = "${suppression.lineComment.text},${group.problemName}"
+    }
+  }
+
+  private fun addNewSuppression(): TextEdit {
+    return TextEdit().apply {
+      val lineText = node.containingFile.contents.lines()[node.span.beginLine - 1]
+      val indent = lineText.takeWhile { it.isWhitespace() }
+      val lineComment = "$indent// noinspection ${group.problemName}\n"
+      val lineStart =
+        Span(
+          beginLine = node.span.beginLine,
+          beginCol = 1,
+          endLine = node.span.beginLine,
+          endCol = 1,
+        )
+      range = lineStart.toRange()
+      newText = lineComment
+    }
+  }
+
+  private fun getEdit(): TextEdit {
+    return node.getSuppression()?.let { addToExistingSuppression(it) } ?: addNewSuppression()
+  }
+
+  override fun toMessage(diagnostic: PklDiagnostic): CodeAction {
+    val self = this
+    return super.toMessage(diagnostic).apply {
+      edit =
+        WorkspaceEdit().apply {
+          changes = mapOf(node.containingFile.lspUri.toString() to listOf(self.getEdit()))
+        }
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/analyzers/Analyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/Analyzer.kt
@@ -15,11 +15,9 @@
  */
 package org.pkl.lsp.analyzers
 
-import org.eclipse.lsp4j.DiagnosticSeverity
 import org.pkl.lsp.Component
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.PklNode
-import org.pkl.lsp.ast.Span
 import org.pkl.lsp.ast.isInStdlib
 
 /**
@@ -28,7 +26,7 @@ import org.pkl.lsp.ast.isInStdlib
  * Diagnostics then get reported back to the user.
  */
 abstract class Analyzer(project: Project) : Component(project) {
-  fun analyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>) {
+  fun analyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder) {
     if (node.isInStdlib) return
     if (!doAnalyze(node, diagnosticsHolder)) {
       return
@@ -42,35 +40,5 @@ abstract class Analyzer(project: Project) : Component(project) {
    * Return `false` if the annotator does not need to analyze any further. This skips calling
    * [doAnalyze] on its children.
    */
-  protected abstract fun doAnalyze(
-    node: PklNode,
-    diagnosticsHolder: MutableList<PklDiagnostic>,
-  ): Boolean
-
-  protected fun warn(
-    node: PklNode,
-    message: String,
-    action: PklDiagnostic.() -> Unit = {},
-  ): PklDiagnostic = PklDiagnostic(node, message, DiagnosticSeverity.Warning).also { action(it) }
-
-  protected fun warn(
-    span: Span,
-    message: String,
-    action: PklDiagnostic.() -> Unit = {},
-  ): PklDiagnostic = PklDiagnostic(span, message, DiagnosticSeverity.Warning).also { action(it) }
-
-  protected fun error(
-    node: PklNode,
-    message: String,
-    action: PklDiagnostic.() -> Unit = {},
-  ): PklDiagnostic = PklDiagnostic(node, message, DiagnosticSeverity.Error).also { action(it) }
-
-  protected fun error(
-    span: Span,
-    message: String,
-    action: PklDiagnostic.() -> Unit = {},
-  ): PklDiagnostic = PklDiagnostic(span, message, DiagnosticSeverity.Error).also { action(it) }
-
-  protected fun newDiagnostic(span: Span, message: String, action: PklDiagnostic.() -> Unit = {}) =
-    PklDiagnostic(span, message, null, null).also { action(it) }
+  protected abstract fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,22 +21,22 @@ import org.pkl.lsp.ast.*
 import org.pkl.lsp.type.computeThisType
 
 class AnnotationAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
     if (node !is PklAnnotation) return true
     val type = node.type ?: return true
     val context = node.containingFile.pklProject
     if (type !is PklDeclaredType) {
-      diagnosticsHolder.add(error(type, ErrorMessages.create("annotationHasNoName")))
+      diagnosticsHolder.addError(type, ErrorMessages.create("annotationHasNoName"))
       return true
     }
 
     val resolvedType = type.name.resolve(context)
     if (resolvedType == null || resolvedType !is PklClass) {
-      diagnosticsHolder.add(error(type, ErrorMessages.create("cannotFindType")))
+      diagnosticsHolder.addError(type, ErrorMessages.create("cannotFindType"))
       return true
     }
     if (resolvedType.isAbstract) {
-      diagnosticsHolder.add(error(type, ErrorMessages.create("typeIsAbstract")))
+      diagnosticsHolder.addError(type, ErrorMessages.create("typeIsAbstract"))
     }
     val base = project.pklBaseModule
     if (
@@ -44,7 +44,7 @@ class AnnotationAnalyzer(project: Project) : Analyzer(project) {
         .computeThisType(base, mapOf(), context)
         .isSubtypeOf(base.annotationType, base, context)
     ) {
-      diagnosticsHolder.add(error(type, ErrorMessages.create("notAnnotation")))
+      diagnosticsHolder.addError(type, ErrorMessages.create("notAnnotation"))
     }
 
     return true

--- a/src/main/kotlin/org/pkl/lsp/analyzers/DiagnosticsHolder.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/DiagnosticsHolder.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.analyzers
+
+import org.eclipse.lsp4j.DiagnosticSeverity
+import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.Span
+
+class DiagnosticsHolder {
+  private val myDiagnostics: MutableList<PklDiagnostic> = mutableListOf()
+
+  val diagnostics: List<PklDiagnostic> = myDiagnostics
+
+  fun addWarning(
+    node: PklNode,
+    message: String,
+    span: Span = node.span,
+    action: PklDiagnostic.() -> Unit = {},
+  ) = addDiagnostic(node, message, span, DiagnosticSeverity.Warning, action)
+
+  fun addError(
+    node: PklNode,
+    message: String,
+    span: Span = node.span,
+    action: PklDiagnostic.() -> Unit = {},
+  ) = addDiagnostic(node, message, span, DiagnosticSeverity.Error, action)
+
+  fun addDiagnostic(
+    node: PklNode,
+    message: String,
+    span: Span = node.span,
+    severity: DiagnosticSeverity? = null,
+    action: PklDiagnostic.() -> Unit = {},
+  ) {
+    val diag = PklDiagnostic(span, message, severity).also { action(it) }
+    doAddDiagnostic(node, diag)
+  }
+
+  private fun doAddDiagnostic(node: PklNode, diagnostic: PklDiagnostic) {
+    if (diagnostic.isSuppressed(node)) {
+      return
+    }
+    diagnostic.problemGroup?.let { problemGroup ->
+      // copy logic in pkl-intellij; only support warning suppression for non-errors.
+      if (diagnostic.severity != DiagnosticSeverity.Error) {
+        diagnostic.actions += problemGroup.getSuppressQuickFixes(node)
+      }
+    }
+    myDiagnostics += diagnostic
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
@@ -33,7 +33,7 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
     private val OBJECT_PROPERTY_MODIFIERS = setOf(LOCAL, CONST)
   }
 
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
     // removing module and module declaration because this will be checked in PklModuleHeader
     if (node !is PklModifierListOwner || node.modifiers == null || node is PklModule) {
       return true
@@ -66,8 +66,9 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
               (hiddenModifier != null || node.typeAnnotation != null)
           ) {
             if (node.identifier != null) {
-              diagnosticsHolder.add(
-                error(node.identifier!!, ErrorMessages.create("missingModifierLocal"))
+              diagnosticsHolder.addError(
+                node.identifier!!,
+                ErrorMessages.create("missingModifierLocal"),
               )
               return true
             }
@@ -77,11 +78,13 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
     }
 
     if (abstractModifier != null && openModifier != null) {
-      diagnosticsHolder.add(
-        error(abstractModifier, ErrorMessages.create("modifierAbstractConflictsWithOpen"))
+      diagnosticsHolder.addError(
+        abstractModifier,
+        ErrorMessages.create("modifierAbstractConflictsWithOpen"),
       )
-      diagnosticsHolder.add(
-        error(openModifier, ErrorMessages.create("modifierOpenConflictsWithAbstract"))
+      diagnosticsHolder.addError(
+        openModifier,
+        ErrorMessages.create("modifierOpenConflictsWithAbstract"),
       )
     }
 
@@ -89,8 +92,10 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
     if (module != null && module.effectivePklVersion >= Version.PKL_VERSION_0_27) {
       // TODO: add a quick-fix
       if (constModifier != null && localModifier == null && node is PklObjectMember) {
-        diagnosticsHolder +=
-          error(constModifier, ErrorMessages.create("invalidModifierConstWithoutLocal"))
+        diagnosticsHolder.addError(
+          constModifier,
+          ErrorMessages.create("invalidModifierConstWithoutLocal"),
+        )
       }
     }
 
@@ -107,11 +112,9 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
       }
     for (modifier in node.modifiers!!) {
       if (modifier.type !in applicableModifiers) {
-        diagnosticsHolder.add(
-          error(
-            modifier,
-            ErrorMessages.create("modifierIsNotApplicable", modifier.text, description),
-          )
+        diagnosticsHolder.addError(
+          modifier,
+          ErrorMessages.create("modifierIsNotApplicable", modifier.text, description),
         )
       }
     }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModuleMemberAnalyzer.kt
@@ -24,7 +24,7 @@ import org.pkl.lsp.ast.PklProperty
 
 class ModuleMemberAnalyzer(project: Project) : Analyzer(project) {
 
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
     val context = node.containingFile.pklProject
     when (node) {
       is PklProperty -> {
@@ -34,8 +34,10 @@ class ModuleMemberAnalyzer(project: Project) : Analyzer(project) {
         if (isAmends && !node.isLocal && supermodule != null) {
           val superProperty = supermodule.properties[node.name]
           if (superProperty == null) {
-            diagnosticsHolder +=
-              warn(node.identifier ?: node, ErrorMessages.create("unresolvedProperty", node.name))
+            diagnosticsHolder.addWarning(
+              node.identifier ?: node,
+              ErrorMessages.create("unresolvedProperty", node.name),
+            )
           }
         }
       }
@@ -43,11 +45,10 @@ class ModuleMemberAnalyzer(project: Project) : Analyzer(project) {
         val isAmends = node.enclosingModule?.isAmend ?: false
 
         if (isAmends && !node.isLocal) {
-          diagnosticsHolder +=
-            error(
-              node.methodHeader.identifier ?: node,
-              ErrorMessages.create("missingModifierLocal"),
-            )
+          diagnosticsHolder.addError(
+            node.methodHeader.identifier ?: node,
+            ErrorMessages.create("missingModifierLocal"),
+          )
         }
       }
     }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroup.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroup.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,20 +15,20 @@
  */
 package org.pkl.lsp.analyzers
 
-import org.pkl.lsp.ErrorMessages
-import org.pkl.lsp.Project
-import org.pkl.lsp.ast.PklError
+import org.pkl.lsp.actions.PklCodeAction
+import org.pkl.lsp.actions.PklSuppressWarningsCodeAction
 import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.PklSuppressWarningsTarget
+import org.pkl.lsp.ast.parentsOfType
 
-class SyntaxAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
-
-    if (node is PklError) {
-      diagnosticsHolder.addError(node, ErrorMessages.create("invalidSyntax"))
-    } else if (node.isMissing) {
-      diagnosticsHolder.addError(node, ErrorMessages.create("missingSyntax", node.text))
+class PklProblemGroup(val problemName: String) {
+  fun getSuppressQuickFixes(node: PklNode): List<PklCodeAction> {
+    if (!node.containingFile.canModify()) return listOf()
+    val self = this
+    return buildList {
+      for (target in node.parentsOfType<PklSuppressWarningsTarget>()) {
+        add(PklSuppressWarningsCodeAction(target, self))
+      }
     }
-
-    return true
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroups.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroups.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.analyzers
+
+// keep in sync with pkl-intellij's problem groups
+object PklProblemGroups {
+  val deprecated: PklProblemGroup = PklProblemGroup("Deprecated")
+
+  val pklVersionMismatch: PklProblemGroup = PklProblemGroup("PklVersionMismatch")
+
+  val unresolvedElement: PklProblemGroup = PklProblemGroup("UnresolvedElement")
+
+  val typeMismatch: PklProblemGroup = PklProblemGroup("TypeMismatch")
+
+  val replaceForGeneratorWithSpread: PklProblemGroup =
+    PklProblemGroup("ReplaceForGeneratorWithSpread")
+
+  val unsupportedFeature: PklProblemGroup = PklProblemGroup("UnsupportedFeature")
+
+  val missingDefaultValue: PklProblemGroup = PklProblemGroup("MissingDefaultValue")
+}

--- a/src/main/kotlin/org/pkl/lsp/analyzers/StringLiteralAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/StringLiteralAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ import org.pkl.lsp.Project
 import org.pkl.lsp.ast.PklNode
 
 class StringLiteralAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
     TODO("Not yet implemented")
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/UnsupportedFeatureAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/UnsupportedFeatureAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,17 @@ import org.pkl.lsp.util.Feature
 
 class UnsupportedFeatureAnalyzer(project: Project) : Analyzer(project) {
 
-  override fun doAnalyze(node: PklNode, diagnosticsHolder: MutableList<PklDiagnostic>): Boolean {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
     val containingModule = node.enclosingModule ?: return false
     val feature = Feature.features.find { it.predicate(node) } ?: return true
     if (feature.isSupported(containingModule)) return true
-    diagnosticsHolder +=
-      error(
-        node,
-        feature.message +
-          "\nRequired Pkl version: `${feature.requiredVersion}`. Detected Pkl version: `${containingModule.effectivePklVersion}`",
-      )
+    diagnosticsHolder.addError(
+      node,
+      feature.message +
+        "\nRequired Pkl version: `${feature.requiredVersion}`. Detected Pkl version: `${containingModule.effectivePklVersion}`",
+    ) {
+      problemGroup = PklProblemGroups.unsupportedFeature
+    }
     return true
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,5 +43,19 @@ class PklStringConstantImpl(
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitStringConstant(this)
+  }
+}
+
+class PklLineCommentImpl(project: Project, parent: PklNode, override val ctx: Node) :
+  AbstractPklNode(project, parent, ctx), PklLineComment {
+  override fun <R> accept(visitor: PklVisitor<R>): R? {
+    return visitor.visitLineComment(this)
+  }
+}
+
+class PklBlockCommentImpl(project: Project, parent: PklNode, override val ctx: Node) :
+  AbstractPklNode(project, parent, ctx), PklBlockComment {
+  override fun <R> accept(visitor: PklVisitor<R>): R? {
+    return visitor.visitBlockComment(this)
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -273,6 +273,8 @@ inline fun <reified T : PklNode> PklNode.parentOfType(): T? {
   return parentOfTypes(T::class)
 }
 
+inline fun <reified T : PklNode> PklNode.parentsOfType(): List<T> = parentsOfTypes(T::class)
+
 fun PklImportBase.resolve(context: PklProject?): ModuleResolutionResult =
   if (isGlob) GlobModuleResolutionResult(moduleUri?.resolveGlob(context) ?: emptyList())
   else SimpleModuleResolutionResult(moduleUri?.resolve(context))

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -30,6 +30,8 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
   override val uri: URI
     get() = virtualFile.uri
 
+  override var index: Int = 0
+
   override val isAmend: Boolean by lazy { header?.moduleExtendsAmendsClause?.isAmend ?: false }
 
   override val header: PklModuleHeader? by lazy { getChild(PklModuleHeaderImpl::class) }

--- a/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
@@ -97,11 +97,11 @@ class DiagnosticsManager(project: Project) : Component(project) {
     return project.cachedValuesManager.getCachedValue(
       "DiagnosticsManager.getDiagnostics(${module.uri})"
     ) {
-      val diagnostics = mutableListOf<PklDiagnostic>()
+      val holder = DiagnosticsHolder()
       for (analyzer in analyzers) {
-        analyzer.analyze(module, diagnostics)
+        analyzer.analyze(module, holder)
       }
-      logger.log("Found ${diagnostics.size} diagnostic errors for ${module.uri}")
+      logger.log("Found ${holder.diagnostics.size} diagnostic errors for ${module.uri}")
       val dependencies = buildList {
         val file = module.containingFile
 
@@ -116,7 +116,7 @@ class DiagnosticsManager(project: Project) : Component(project) {
           add(project.pklProjectManager.syncTracker)
         }
       }
-      CachedValue(diagnostics, dependencies)
+      CachedValue(holder.diagnostics, dependencies)
     }!!
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/util/Edits.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/Edits.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.util
+
+import org.eclipse.lsp4j.Range
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent
+import org.eclipse.lsp4j.TextEdit
+import org.pkl.lsp.getIndex
+
+object Edits {
+  data class Edit(val range: Range?, val text: String)
+
+  fun applyTextEdits(original: String, edits: List<TextEdit>): String {
+    return apply(original, edits.map { it.toEdit() })
+  }
+
+  fun applyChangeEvents(original: String, edits: List<TextDocumentContentChangeEvent>): String {
+    return apply(original, edits.map { it.toEdit() })
+  }
+
+  fun apply(original: String, edits: List<Edit>): String {
+    var result = original
+    for (change in edits) {
+      if (change.range == null) {
+        result = change.text
+      } else {
+        val startIndex = result.getIndex(change.range.start)
+        val endIndex = result.getIndex(change.range.end)
+        result = result.replaceRange(startIndex, endIndex, change.text)
+      }
+    }
+    return result
+  }
+
+  private fun TextDocumentContentChangeEvent.toEdit(): Edit {
+    return Edit(range = range, text = text)
+  }
+
+  private fun TextEdit.toEdit(): Edit {
+    return Edit(range = range, text = newText)
+  }
+}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/suppression/basic.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/suppression/basic.pkl
@@ -1,0 +1,4 @@
+bar: String?
+
+// noinspection TypeMismatch
+foo: String = bar

--- a/src/test/files/DiagnosticsSnippetTests/inputs/suppression/multipleSuppressions.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/suppression/multipleSuppressions.pkl
@@ -1,0 +1,10 @@
+bar: String?
+
+// noinspection Foo,TypeMismatch
+foo: String = bar
+
+// noinspection Biz, TypeMismatch, Qux
+qux: String = bar
+
+// noinspection Biz,TypeMismatch,Qux
+corge: String = bar

--- a/src/test/files/DiagnosticsSnippetTests/inputs/suppression/nested.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/suppression/nested.pkl
@@ -1,0 +1,6 @@
+const bar: String?
+
+// noinspection TypeMismatch
+class Bar {
+  foo: String = bar
+}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/suppression/suppressCorrectTarget.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/suppression/suppressCorrectTarget.pkl
@@ -1,0 +1,8 @@
+// Assert that we get the very previous line comment.
+// This should still result in a warning diagnostic.
+bar: String?
+
+// noinspection TypeMismatch
+qux = 5
+
+foo: String = bar

--- a/src/test/files/DiagnosticsSnippetTests/outputs/suppression/basic.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/suppression/basic.txt
@@ -1,0 +1,5 @@
+ bar: String?
+ 
+ // noinspection TypeMismatch
+ foo: String = bar
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/suppression/multipleSuppressions.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/suppression/multipleSuppressions.txt
@@ -1,0 +1,11 @@
+ bar: String?
+ 
+ // noinspection Foo,TypeMismatch
+ foo: String = bar
+ 
+ // noinspection Biz, TypeMismatch, Qux
+ qux: String = bar
+ 
+ // noinspection Biz,TypeMismatch,Qux
+ corge: String = bar
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/suppression/nested.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/suppression/nested.txt
@@ -1,0 +1,7 @@
+ const bar: String?
+ 
+ // noinspection TypeMismatch
+ class Bar {
+   foo: String = bar
+ }
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/suppression/suppressCorrectTarget.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/suppression/suppressCorrectTarget.txt
@@ -1,0 +1,13 @@
+ // Assert that we get the very previous line comment.
+ // This should still result in a warning diagnostic.
+ bar: String?
+ 
+ // noinspection TypeMismatch
+ qux = 5
+ 
+ foo: String = bar
+               ^^^
+| Warning: Nullability mismatch.
+| Required: String
+| Actual: String?
+ 

--- a/src/test/files/ParserSnippetTests/outputs/expr/binaryExprWithComments.txt
+++ b/src/test/files/ParserSnippetTests/outputs/expr/binaryExprWithComments.txt
@@ -2,12 +2,15 @@ PklModuleImpl
   PklClassPropertyImpl
     PklLogicalOrExprImpl
       PklIntLiteralExprImpl
+      PklLineCommentImpl
       PklIntLiteralExprImpl
   PklClassPropertyImpl
     PklAdditiveExprImpl
       PklIntLiteralExprImpl
+      PklBlockCommentImpl
       PklIntLiteralExprImpl
   PklClassPropertyImpl
     PklNullCoalesceExprImpl
       PklIntLiteralExprImpl
+      PklLineCommentImpl
       PklIntLiteralExprImpl

--- a/src/test/kotlin/org/pkl/lsp/ParserTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/ParserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,9 +38,9 @@ class ParserTest {
         .trimIndent()
 
     val mod = parse(code)
-    val prop = mod.children[0]
+    val prop = mod.children[1]
     assertThat(prop.text).isEqualTo("const `fo©o` = 1")
-    val prop2 = mod.children[1]
+    val prop2 = mod.children[2]
     assertThat(prop2.text).isEqualTo("bar = 3")
   }
 

--- a/src/test/kotlin/org/pkl/lsp/SuppressWarningsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SuppressWarningsTest.kt
@@ -1,0 +1,113 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class SuppressWarningsTest : LspTestBase() {
+  @Test
+  fun `add suppression`() {
+    val file =
+      createPklVirtualFile(
+        """
+     const bar: Int?
+
+     class Bar {
+       foo: Int = bar
+     }
+    """
+          .trimIndent()
+      )
+    val diagnostic = getSingleDiagnostic(file)
+    assertThat(diagnostic.actions).hasSize(2)
+    assertThat(diagnostic.actions[0].title).isEqualTo("Suppress 'TypeMismatch' for property 'foo'")
+    assertThat(diagnostic.actions[1].title).isEqualTo("Suppress 'TypeMismatch' for class 'Bar'")
+    runAction(diagnostic.actions[0].toMessage(diagnostic))
+    assertThat(file.contents)
+      .isEqualTo(
+        """
+     const bar: Int?
+
+     class Bar {
+       // noinspection TypeMismatch
+       foo: Int = bar
+     }
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `add suppression to class`() {
+    val file =
+      createPklVirtualFile(
+        """
+     const bar: Int?
+
+     class Bar {
+       foo: Int = bar
+     }
+    """
+          .trimIndent()
+      )
+    val diagnostic = getSingleDiagnostic(file)
+    assertThat(diagnostic.actions[1].title).isEqualTo("Suppress 'TypeMismatch' for class 'Bar'")
+    runAction(diagnostic.actions[1].toMessage(diagnostic))
+    assertThat(file.contents)
+      .isEqualTo(
+        """
+      const bar: Int?
+  
+      // noinspection TypeMismatch
+      class Bar {
+        foo: Int = bar
+      }
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `add suppression to already existing line comment`() {
+    val file =
+      createPklVirtualFile(
+        """
+     const bar: Int?
+
+     class Bar {
+       // noinspection FooBar
+       foo: Int = bar
+     }
+    """
+          .trimIndent()
+      )
+    val diagnostic = getSingleDiagnostic(file)
+    runAction(diagnostic.actions[0].toMessage(diagnostic))
+    assertThat(file.contents)
+      .isEqualTo(
+        """
+     const bar: Int?
+
+     class Bar {
+       // noinspection FooBar,TypeMismatch
+       foo: Int = bar
+     }
+    """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
This adds a way to suppress warnings for certain diagnostics, matching how we handle this in pkl-intellij.

* Don't emit diagnostics for problem groups that are suppressed
* Add PklSuppresWarningTarget as a node type
* Add DiagnosticsHolder class that knows whether to emit diagnostics, based on what's been suppressed.
* Add PklLineComment and PklBlockComment nodes
* Add code actions for injection warning suppression comments
* Add support for suppressing TypeMismatch, UnresolvedElement, UnsupportedFeature

NOTE: only the last commit in this PR is relevant; this is built on top of https://github.com/apple/pkl-lsp/pull/71