### PR TITLE
Miscellaneous fixes

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklTextDocumentService.kt
@@ -51,9 +51,6 @@ class PklTextDocumentService(project: Project) : Component(project), TextDocumen
 
   override fun didOpen(params: DidOpenTextDocumentParams) {
     val uri = URI(params.textDocument.uri)
-    project.virtualFileManager.get(uri)?.let { file ->
-      file.version = params.textDocument.version.toLong()
-    }
     project.messageBus.emit(textDocumentTopic, TextDocumentEvent.Opened(uri))
   }
 

--- a/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,10 @@ package org.pkl.lsp
 
 import java.net.URI
 import java.nio.file.*
-import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 class VirtualFileManager(project: Project) : Component(project) {
-  private val files: MutableMap<URI, BaseFile> = Collections.synchronizedMap(WeakHashMap())
+  private val files: MutableMap<URI, BaseFile> = ConcurrentHashMap()
 
   fun get(path: Path): VirtualFile? {
     return if (!Files.exists(path)) null else get(path.toUri(), path)

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -143,7 +143,7 @@ class PklModuleClauseImpl(
     getChild(PklQualifiedIdentifierImpl::class)
   }
 
-  override val modifiers: List<Terminal>? by lazy { terminals.takeWhile { it.isModifier } }
+  override val modifiers: List<Terminal>? by lazy { terminals.filter { it.isModifier } }
 
   override val shortDisplayName: String? by lazy {
     qualifiedIdentifier?.fullName?.substringAfterLast('.')
@@ -186,9 +186,7 @@ class PklImportImpl(
   override val parent: PklNode,
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklImport {
-  override val identifier: Terminal? by lazy {
-    ctx.children.find { it.type == "identifier" }?.toTerminal(this)
-  }
+  override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
 
   override val isGlob: Boolean by lazy { ctx.type == "importGlobClause" }
 
@@ -234,7 +232,7 @@ class PklClassImpl(
 
   override val name: String by lazy { identifier!!.text }
 
-  override val modifiers: List<Terminal>? by lazy { terminals.takeWhile { it.isModifier } }
+  override val modifiers: List<Terminal>? by lazy { terminals.filter { it.isModifier } }
 
   override fun cache(context: PklProject?): ClassMemberCache =
     ClassMemberCache.create(this, context)

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,7 +162,7 @@ class PklDefaultUnionTypeImpl(project: Project, override val parent: PklNode, ct
 
 class PklTypeAliasImpl(project: Project, override val parent: PklNode?, ctx: Node) :
   AbstractPklNode(project, parent, ctx), PklTypeAlias {
-  override val modifiers: List<Terminal>? by lazy { terminals.takeWhile { it.isModifier } }
+  override val modifiers: List<Terminal>? by lazy { terminals.filter { it.isModifier } }
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val name: String by lazy { identifier!!.text }
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }

--- a/src/test/kotlin/org/pkl/lsp/ParserTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/ParserTest.kt
@@ -137,6 +137,21 @@ class ParserTest {
     assertThat(err!!.text).isEqualTo(".]")
   }
 
+  @Test
+  fun `parse modifiers with preceding line comments`() {
+    val code =
+      """
+      // some line comment
+      abstract function foo()
+    """
+        .trimIndent()
+
+    val mod = parse(code)
+    val method = mod.methods.first()
+    assertThat(method.modifiers).hasSize(1)
+    assertThat(method.modifiers!!.first().type).isEqualTo(TokenType.ABSTRACT)
+  }
+
   private fun assertClassPropertyExpr(node: PklNode): PklExpr {
     assertThat(node).isInstanceOf(PklClassProperty::class.java)
     val expr = (node as PklClassProperty).expr


### PR DESCRIPTION
This fixes various issues in the LSP

* Fixes parsing of modifier nodes
* Fixes an issue where child nodes are constructed twice (`toNode()`, `toTerminal()` should never be called in the body of a class because they are already initialized when `children` is called)
* Improves child node selection by using field names
* Fixes an issue where stdlib modules can possibly be initialized multiple times
* Fixes possible race conditions to prevent a cached value's provider from being called multiple times
* Treat `PklMethod` as an identifier owner, so that code actions that target them can refer to them by name.
* Cache the result of `computeExprType`