### PR TITLE
Add analysis for type names

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/AnnotationAnalyzer.kt
@@ -31,12 +31,17 @@ class AnnotationAnalyzer(project: Project) : Analyzer(project) {
     }
 
     val resolvedType = type.name.resolve(context)
-    if (resolvedType == null || resolvedType !is PklClass) {
-      diagnosticsHolder.addError(type, ErrorMessages.create("cannotFindType"))
-      return true
+    // unresolved type name is handled by TypeNameAnalyzer
+    if (resolvedType == null) {
+      return false
+    }
+    if (resolvedType !is PklClass) {
+      diagnosticsHolder.addError(type, ErrorMessages.create("notAnnotation"))
+      return false
     }
     if (resolvedType.isAbstract) {
       diagnosticsHolder.addError(type, ErrorMessages.create("typeIsAbstract"))
+      return false
     }
     val base = project.pklBaseModule
     if (
@@ -47,6 +52,6 @@ class AnnotationAnalyzer(project: Project) : Analyzer(project) {
       diagnosticsHolder.addError(type, ErrorMessages.create("notAnnotation"))
     }
 
-    return true
+    return false
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/TypeNameAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/TypeNameAnalyzer.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.analyzers
+
+import org.pkl.lsp.ErrorMessages
+import org.pkl.lsp.Project
+import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.PklTypeName
+import org.pkl.lsp.ast.resolve
+
+class TypeNameAnalyzer(project: Project) : Analyzer(project) {
+  override fun doAnalyze(node: PklNode, holder: DiagnosticsHolder): Boolean {
+    when (node) {
+      is PklTypeName -> {
+        val moduleName = node.moduleName
+        val context = node.containingFile.pklProject
+        if (moduleName != null) {
+          val resolvedModule = moduleName.resolve(context)
+          if (resolvedModule == null) {
+            moduleName.identifier?.let { identifier ->
+              holder.addError(
+                moduleName,
+                ErrorMessages.create("unresolvedReference", identifier.text),
+              )
+            }
+            return false
+          }
+        }
+        val typeName = node.simpleTypeName
+        val resolvedType = typeName.resolve(context)
+        if (resolvedType == null) {
+          typeName.identifier?.let { identifier ->
+            holder.addError(
+              node.simpleTypeName,
+              ErrorMessages.create("unresolvedReference", identifier.text),
+            )
+          }
+          return false
+        }
+      }
+    }
+    return true
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/analyzers/TypeNameAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/TypeNameAnalyzer.kt
@@ -22,36 +22,32 @@ import org.pkl.lsp.ast.PklTypeName
 import org.pkl.lsp.ast.resolve
 
 class TypeNameAnalyzer(project: Project) : Analyzer(project) {
-  override fun doAnalyze(node: PklNode, holder: DiagnosticsHolder): Boolean {
-    when (node) {
-      is PklTypeName -> {
-        val moduleName = node.moduleName
+  override fun doAnalyze(node: PklNode, holder: DiagnosticsHolder): Boolean =
+    when {
+      node is PklTypeName -> {
         val context = node.containingFile.pklProject
-        if (moduleName != null) {
-          val resolvedModule = moduleName.resolve(context)
-          if (resolvedModule == null) {
-            moduleName.identifier?.let { identifier ->
+        when {
+          node.moduleName != null && node.moduleName!!.resolve(context) == null -> {
+            node.moduleName!!.identifier?.let {
               holder.addError(
-                moduleName,
-                ErrorMessages.create("unresolvedReference", identifier.text),
+                node.moduleName!!,
+                ErrorMessages.create("unresolvedReference", it.text),
               )
             }
-            return false
+            false
           }
-        }
-        val typeName = node.simpleTypeName
-        val resolvedType = typeName.resolve(context)
-        if (resolvedType == null) {
-          typeName.identifier?.let { identifier ->
-            holder.addError(
-              node.simpleTypeName,
-              ErrorMessages.create("unresolvedReference", identifier.text),
-            )
+          node.simpleTypeName.resolve(context) == null -> {
+            node.simpleTypeName.identifier?.let {
+              holder.addError(
+                node.simpleTypeName,
+                ErrorMessages.create("unresolvedReference", it.text),
+              )
+            }
+            false
           }
-          return false
+          else -> true
         }
       }
+      else -> true
     }
-    return true
-  }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Basic.kt
@@ -24,6 +24,7 @@ class PklQualifiedIdentifierImpl(
   override val parent: PklNode,
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklQualifiedIdentifier {
+
   override val identifiers: List<Terminal> by lazy {
     terminals.filter { it.type == TokenType.Identifier }
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -623,3 +623,6 @@ fun Appendable.renderParameterList(
 
   return this
 }
+
+fun <T> List<T>.withReplaced(idx: Int, elem: T): List<T> =
+  toMutableList().apply { this[idx] = elem }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -855,7 +855,7 @@ fun Node.toNode(project: Project, parent: PklNode?): PklNode? {
     "clazz" -> PklClassImpl(project, parent!!, this)
     "classBody" -> PklClassBodyImpl(project, parent!!, this)
     // This is kinda of a hack but works because they have the same children
-    "classExtendsClause" -> PklDeclaredTypeImpl(project, parent!!, this)
+    "classExtendsClause" -> PklDeclaredTypeImpl(project, parent!!, this, false)
     "classProperty" -> PklClassPropertyImpl(project, parent!!, this)
     "methodHeader" -> PklMethodHeaderImpl(project, parent!!, this)
     "classMethod" -> PklClassMethodImpl(project, parent!!, this)
@@ -869,7 +869,7 @@ fun Node.toNode(project: Project, parent: PklNode?): PklNode? {
     "nothingType" -> PklNothingTypeImpl(project, parent!!, this)
     "moduleType" -> PklModuleTypeImpl(project, parent!!, this)
     "stringLiteralType" -> PklStringLiteralTypeImpl(project, parent!!, this)
-    "declaredType" -> PklDeclaredTypeImpl(project, parent!!, this)
+    "declaredType" -> PklDeclaredTypeImpl(project, parent!!, this, false)
     "parenthesizedType" -> PklParenthesizedTypeImpl(project, parent!!, this)
     "functionLiteralType" -> PklFunctionTypeImpl(project, parent!!, this)
     // TODO: for pkl-tree-sitter `*Foo` alone is a valid type

--- a/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
@@ -38,6 +38,7 @@ class DiagnosticsManager(project: Project) : Component(project) {
       TypeCheckAnalyzer(project),
       AccessExprAnalyzer(project),
       ExprAnalyzer(project),
+      TypeNameAnalyzer(project),
     )
 
   private val openFiles: MutableMap<URI, Boolean> = ConcurrentHashMap()

--- a/src/test/files/DiagnosticsSnippetTests/inputs/typename/unresolved.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/typename/unresolved.pkl
@@ -1,0 +1,19 @@
+import "pkl:json"
+
+typealias Foo = Bar.Baz
+
+typealias Qux = Baz
+
+typealias Fooey = json.Fooey
+
+prop1: Bar.Baz
+
+prop2: Baz
+
+prop3: json.Fooey
+
+@Baz
+prop4: Int
+
+@Bar.Baz
+prop5: Int

--- a/src/test/files/DiagnosticsSnippetTests/outputs/typename/unresolved.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/typename/unresolved.txt
@@ -1,0 +1,36 @@
+ import "pkl:json"
+ 
+ typealias Foo = Bar.Baz
+                 ^^^
+| Error: Unresolved reference `Bar`
+ 
+ typealias Qux = Baz
+                 ^^^
+| Error: Unresolved reference `Baz`
+ 
+ typealias Fooey = json.Fooey
+                        ^^^^^
+| Error: Unresolved reference `Fooey`
+ 
+ prop1: Bar.Baz
+        ^^^
+| Error: Unresolved reference `Bar`
+ 
+ prop2: Baz
+        ^^^
+| Error: Unresolved reference `Baz`
+ 
+ prop3: json.Fooey
+             ^^^^^
+| Error: Unresolved reference `Fooey`
+ 
+ @Baz
+  ^^^
+| Error: Unresolved reference `Baz`
+ prop4: Int
+ 
+ @Bar.Baz
+  ^^^
+| Error: Unresolved reference `Bar`
+ prop5: Int
+ 

--- a/src/test/files/ParserSnippetTests/outputs/expr/typeTestAndCast.txt
+++ b/src/test/files/ParserSnippetTests/outputs/expr/typeTestAndCast.txt
@@ -5,9 +5,11 @@ PklModuleImpl
         PklTypeTestExprImpl
           PklUnqualifiedAccessExprImpl
           PklDeclaredTypeImpl
-            PklQualifiedIdentifierImpl
+            PklTypeNameImpl
+              PklQualifiedIdentifierImpl
       PklObjectElementImpl
         PklTypeCastExprImpl
           PklUnqualifiedAccessExprImpl
           PklDeclaredTypeImpl
-            PklQualifiedIdentifierImpl
+            PklTypeNameImpl
+              PklQualifiedIdentifierImpl

--- a/src/test/files/ParserSnippetTests/outputs/types/types.txt
+++ b/src/test/files/ParserSnippetTests/outputs/types/types.txt
@@ -15,27 +15,33 @@ PklModuleImpl
   PklClassPropertyImpl
     PklTypeAnnotationImpl
       PklDeclaredTypeImpl
-        PklQualifiedIdentifierImpl
+        PklTypeNameImpl
+          PklQualifiedIdentifierImpl
         PklTypeArgumentListImpl
           PklDeclaredTypeImpl
-            PklQualifiedIdentifierImpl
+            PklTypeNameImpl
+              PklQualifiedIdentifierImpl
           PklDeclaredTypeImpl
-            PklQualifiedIdentifierImpl
+            PklTypeNameImpl
+              PklQualifiedIdentifierImpl
   PklClassPropertyImpl
     PklTypeAnnotationImpl
       PklParenthesizedTypeImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
   PklClassPropertyImpl
     PklTypeAnnotationImpl
       PklNullableTypeImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
   PklClassPropertyImpl
     PklTypeAnnotationImpl
       PklConstrainedTypeImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
         PklLogicalNotExprImpl
           PklUnqualifiedAccessExprImpl
         PklLogicalNotExprImpl
@@ -44,16 +50,21 @@ PklModuleImpl
     PklTypeAnnotationImpl
       PklUnionTypeImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
         PklDefaultUnionTypeImpl
           PklDeclaredTypeImpl
-            PklQualifiedIdentifierImpl
+            PklTypeNameImpl
+              PklQualifiedIdentifierImpl
   PklClassPropertyImpl
     PklTypeAnnotationImpl
       PklFunctionTypeImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl
         PklDeclaredTypeImpl
-          PklQualifiedIdentifierImpl
+          PklTypeNameImpl
+            PklQualifiedIdentifierImpl


### PR DESCRIPTION
This adds diagnostics like "Unresolved reference 'Foo'" when used as a type name.

As part of this, the parse tree is also fixed to better match the IntelliJ parse tree.