### PR TITLE
Fix qualified access analysis

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -330,7 +330,9 @@ class PklQualifiedAccessExprImpl(
 ) : AbstractPklNode(project, parent, ctx), PklQualifiedAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val memberNameText: String by lazy { identifier!!.text }
-  override val isNullSafeAccess: Boolean by lazy { ctx.children[1].type == ".?" }
+  override val isNullSafeAccess: Boolean by lazy {
+    terminals.find { it.type == TokenType.QDOT } != null
+  }
   override val argumentList: PklArgumentList? by lazy {
     children.firstInstanceOf<PklArgumentList>()
   }

--- a/src/test/files/DiagnosticsSnippetTests/inputs/expr/redundant2.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/expr/redundant2.pkl
@@ -1,0 +1,3 @@
+foo: String?
+
+res = foo?.base64 ?? "hello"

--- a/src/test/files/DiagnosticsSnippetTests/outputs/expr/redundant2.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/expr/redundant2.txt
@@ -1,0 +1,4 @@
+ foo: String?
+ 
+ res = foo?.base64 ?? "hello"
+ 


### PR DESCRIPTION
Fixes an issue where `foo?.bar` is not seen as null propagating