### PR TITLE
Fix an issue that causes the typecheck analyzer to short-circuit

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/TypeCheckAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/TypeCheckAnalyzer.kt
@@ -31,13 +31,13 @@ class TypeCheckAnalyzer(project: Project) : Analyzer(project) {
   override fun doAnalyze(node: PklNode, holder: DiagnosticsHolder): Boolean {
     if (node !is PklExpr) return true
 
-    val module = node.enclosingModule ?: return true
+    val module = node.enclosingModule ?: return false
     val project = module.project
     val base = project.pklBaseModule
     val context = node.containingFile.pklProject
 
     val expectedType = node.inferExprTypeFromContext(base, mapOf(), context)
-    if (expectedType == Type.Unknown) return false
+    if (expectedType == Type.Unknown) return true
 
     val exprType = node.computeExprType(base, mapOf(), context)
     val exprValue = lazy { node.toConstraintExpr(base, context).evaluate(ConstraintValue.Error) }

--- a/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/constraints.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/constraints.pkl
@@ -53,3 +53,13 @@ datasize5: DataSize(isDecimalUnit) = 5.mib
 string1: String(isEmpty) = "hello"
 
 string2: String(isRegex) = "\\"
+
+typealias MyStr = String(matches(Regex(#"\d*"#)))
+
+listing1 = new Listing<MyStr> {
+  "Invalid"
+}
+
+listing2: Listing<MyStr> = new {
+  "Invalid"
+}

--- a/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/constraints.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/constraints.txt
@@ -166,3 +166,20 @@
 | Required: isRegex
 | Found: "\"
  
+ typealias MyStr = String(matches(Regex(#"\d*"#)))
+ 
+ listing1 = new Listing<MyStr> {
+   "Invalid"
+   ^^^^^^^^^
+| Error: Constraint violation.
+| Required: matches(Regex(#"\d*"#))
+| Found: "Invalid"
+ }
+ 
+ listing2: Listing<MyStr> = new {
+   "Invalid"
+   ^^^^^^^^^
+| Error: Constraint violation.
+| Required: matches(Regex(#"\d*"#))
+| Found: "Invalid"
+ }


### PR DESCRIPTION
The analyzer should keep analyzing past nodes whose types are unknown, because they might have children whose types are known.