### PR TITLE
Improve modifier analysis

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/actions/PklAddModifierQuickFix.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklAddModifierQuickFix.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.actions
+
+import org.eclipse.lsp4j.CodeActionDisabled
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.TextEdit
+import org.pkl.lsp.ast.PklModifierListOwner
+import org.pkl.lsp.ast.TokenType
+
+class PklAddModifierQuickFix(
+  override val node: PklModifierListOwner,
+  override val title: String,
+  private val modifier: TokenType,
+) : PklLocalEditCodeAction(node) {
+  override fun getEdits(): List<TextEdit> {
+    return listOf(getEdit())
+  }
+
+  private fun getEdit(): TextEdit {
+    val sortOrder = modifier.sortOrder
+    val anchor = node.modifiers?.find { it.type.sortOrder >= sortOrder }
+    if (anchor != null) {
+      return insertBefore(anchor, modifier.sourceCode + " ")
+    }
+    return insertBefore(node.terminals.first(), modifier.sourceCode + " ")
+  }
+
+  override val kind: String = CodeActionKind.QuickFix
+
+  override val disabled: CodeActionDisabled? = null
+}
+
+private val TokenType.sortOrder: Int
+  get() =
+    when (this) {
+      TokenType.ABSTRACT -> 0
+      TokenType.OPEN -> 0
+      TokenType.FIXED -> 0
+      TokenType.CONST -> 0
+      TokenType.HIDDEN -> 1
+      TokenType.LOCAL -> 1
+      TokenType.EXTERNAL -> 2
+      else -> 3
+    }
+
+private val TokenType.sourceCode: String
+  get() =
+    when (this) {
+      TokenType.ABSTRACT -> "abstract"
+      TokenType.OPEN -> "open"
+      TokenType.FIXED -> "fixed"
+      TokenType.CONST -> "const"
+      TokenType.HIDDEN -> "hidden"
+      TokenType.LOCAL -> "local"
+      TokenType.EXTERNAL -> "external"
+      else -> throw AssertionError("Unknown modifier $this")
+    }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroup.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/PklProblemGroup.kt
@@ -16,7 +16,7 @@
 package org.pkl.lsp.analyzers
 
 import org.pkl.lsp.actions.PklCodeAction
-import org.pkl.lsp.actions.PklSuppressWarningsCodeAction
+import org.pkl.lsp.actions.PklSuppressWarningsQuickFix
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.PklSuppressWarningsTarget
 import org.pkl.lsp.ast.parentsOfType
@@ -27,7 +27,7 @@ class PklProblemGroup(val problemName: String) {
     val self = this
     return buildList {
       for (target in node.parentsOfType<PklSuppressWarningsTarget>()) {
-        add(PklSuppressWarningsCodeAction(target, self))
+        add(PklSuppressWarningsQuickFix(target, self))
       }
     }
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -84,7 +84,7 @@ interface PklNode {
   }
 }
 
-interface PklSuppressWarningsTarget : PklNode {
+sealed interface PklSuppressWarningsTarget : PklNode {
   fun getKind(): String =
     when (this) {
       is PklImport -> "import"

--- a/src/main/kotlin/org/pkl/lsp/ast/Span.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Span.kt
@@ -32,6 +32,9 @@ data class Span(val beginLine: Int, val beginCol: Int, val endLine: Int, val end
       else -> true
     }
 
+  /** Returns a zero-length span at the first position of this span. */
+  fun firstCaret(): Span = Span(beginLine, beginCol, beginLine, beginCol)
+
   fun drop(offset: Int): Span = Span(beginLine, beginCol + offset, endLine, endCol)
 
   fun spliceLine(offset: Int, length: Int): Span =

--- a/src/test/kotlin/org/pkl/lsp/ModifierQuickfixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/ModifierQuickfixTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+class ModifierQuickfixTest : LspTestBase() {
+  @Test
+  fun `add modifier 'local' - no existing modifiers`() {
+    val file =
+      createPklVirtualFile(
+        """
+     amends "pkl:test"
+
+     foo: String = "Hello"
+    """
+          .trimIndent()
+      )
+    val diagnostic = getSingleDiagnostic(file)
+    assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
+    val action = diagnostic.actions.find { it.title == "Add modifier 'local'" }
+    assertThat(action).isNotNull
+    runAction(action!!.toMessage(diagnostic))
+    assertThat(file.contents)
+      .isEqualTo(
+        """
+     amends "pkl:test"
+
+     local foo: String = "Hello"
+    """
+          .trimIndent()
+      )
+  }
+
+  @Test
+  fun `add modifier 'local' - existing modifiers`() {
+    val file =
+      createPklVirtualFile(
+        """
+     amends "pkl:test"
+
+     abstract external foo: String = "Hello"
+    """
+          .trimIndent()
+      )
+    val diagnostic = getSingleDiagnostic(file)
+    assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
+    val action = diagnostic.actions.find { it.title == "Add modifier 'local'" }
+    assertThat(action).isNotNull
+    runAction(action!!.toMessage(diagnostic))
+    // modifier gets inserted in between 'abstract' and 'external'
+    assertThat(file.contents)
+      .isEqualTo(
+        """
+     amends "pkl:test"
+
+     abstract local external foo: String = "Hello"
+    """
+          .trimIndent()
+      )
+  }
+}


### PR DESCRIPTION
* Add quickfix to add 'local' modifier
* Add diagnostic for non-local object properties with type annotations
* Misc: Rename: PklSuppressWarningsCodeAction -> PklSuppressWarningsQuickFix