### PR TITLE
Fix deadlock

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/Member.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Member.kt
@@ -203,6 +203,8 @@ class PklObjectBodyImpl(
   override val parent: PklNode,
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklObjectBody {
+  private val lock = Object()
+
   override val parameters: PklParameterList? by lazy {
     children.firstInstanceOf<PklParameterList>()
   }
@@ -220,7 +222,7 @@ class PklObjectBodyImpl(
   }
 
   override fun isConstScope(): Boolean {
-    return project.cachedValuesManager.getCachedValue(this, "isConstScope()") {
+    return project.cachedValuesManager.getCachedValue(this, "isConstScope()", lock) {
       val parentProperty = parentOfTypes(PklProperty::class, PklMethod::class)
       val isConstScope =
         if (parentProperty?.isConst == true) {

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -50,9 +50,11 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
     header?.moduleExtendsAmendsClause?.moduleUri
   }
 
+  private val lock = Object()
+
   // This is cached at the VirtualFile level
   override fun supermodule(context: PklProject?): PklModule? =
-    project.cachedValuesManager.getCachedValue(this, "supermodule") {
+    project.cachedValuesManager.getCachedValue(this, "supermodule", lock) {
       val resolved = extendsAmendsUri?.resolve(context)
       CachedValue(resolved, listOfNotNull(this.containingFile, resolved?.containingFile))
     }
@@ -61,6 +63,7 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
     project.cachedValuesManager.getCachedValue(
       this,
       "PklModule.cache(${virtualFile.uri}, ${context?.projectDir}}",
+      lock,
     ) {
       val cache = ModuleMemberCache.create(this, context)
       CachedValue(cache, cache.dependencies + project.pklProjectManager.syncTracker)

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,8 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
 
   companion object {
 
+    private val lock = Object()
+
     fun resolve(
       project: Project,
       targetUri: String,
@@ -78,7 +80,8 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
       context: PklProject?,
     ): List<VirtualFile>? =
       element.project.cachedValuesManager.getCachedValue(
-        "PklModuleUri.resolveGlob($targetUriString, $moduleUriString, ${element.containingFile.path}, ${context?.projectDir})"
+        "PklModuleUri.resolveGlob($targetUriString, $moduleUriString, ${element.containingFile.path}, ${context?.projectDir})",
+        lock,
       ) {
         val result =
           doResolveGlob(targetUriString, moduleUriString, element, context)

--- a/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
@@ -44,6 +44,8 @@ class DiagnosticsManager(project: Project) : Component(project) {
   private val openFiles: MutableMap<URI, Boolean> = ConcurrentHashMap()
   private val downloadPackageTracker = SimpleModificationTracker()
 
+  private val lock = Object()
+
   override fun initialize(): CompletableFuture<*> {
     project.messageBus.subscribe(textDocumentTopic, ::handleTextDocumentEvent)
     project.messageBus.subscribe(projectTopic, ::handleProjectEvent)
@@ -96,7 +98,8 @@ class DiagnosticsManager(project: Project) : Component(project) {
 
   fun getDiagnostics(module: PklModule): List<PklDiagnostic> {
     return project.cachedValuesManager.getCachedValue(
-      "DiagnosticsManager.getDiagnostics(${module.uri})"
+      "DiagnosticsManager.getDiagnostics(${module.uri})",
+      lock,
     ) {
       val holder = DiagnosticsHolder()
       for (analyzer in analyzers) {

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeExprType.kt
@@ -33,6 +33,7 @@ fun PklNode?.computeExprType(
       project.cachedValuesManager.getCachedValue(
         containingFile,
         "computeExprType(${System.identityHashCode(this)})",
+        lock = this,
       ) {
         val result = doComputeExprType(base, bindings, context)
         val dependencies = buildList {

--- a/src/main/kotlin/org/pkl/lsp/util/CachedValuesManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/CachedValuesManager.kt
@@ -68,16 +68,17 @@ class CachedValuesManager(project: Project) : Component(project), CachedValueDat
   fun <T> getCachedValue(
     holder: CachedValueDataHolder,
     key: String,
+    lock: Any,
     provider: () -> CachedValue<T>?,
   ): T? {
-    synchronized(holder) {
+    synchronized(lock) {
       return getValue<T>(holder, key)?.value
         ?: provider()?.also { storeCachedValue(holder, key, it) }?.value
     }
   }
 
-  fun <T> getCachedValue(key: String, provider: () -> CachedValue<T>?): T? =
-    getCachedValue(this, key, provider)
+  fun <T> getCachedValue(key: String, lock: Any, provider: () -> CachedValue<T>?): T? =
+    getCachedValue(this, key, lock, provider)
 
   fun clearCachedValue(holder: CachedValueDataHolder, key: String) {
     holder.cachedValues.remove(key)


### PR DESCRIPTION
This fixes a deadlock that arises when computing diagnostics.

This also generally reduces lock contention (the `getCachedValues()` API now requires a lock to be provided).