### PR TITLE
Resolve modulepath imports from local file

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package org.pkl.lsp.ast
 
 import io.github.treesitter.jtreesitter.Node
+import java.nio.file.Files
 import java.nio.file.Path
 import org.pkl.lsp.*
 import org.pkl.lsp.FsFile
@@ -121,6 +122,16 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
             getDependencyRoot(project, targetUriStr, enclosingModule, context)
               ?.resolve(targetUri.fragment)
           vfile?.getModule()?.get()
+        }
+        "modulepath" -> {
+          val path = targetUri.path.trimStart('/')
+          val absolutePath =
+            project.pklProjectManager.findModulePath().map { it.resolve(path) }.first(Files::exists)
+              ?: return null
+          return sourceFile.project.virtualFileManager
+            .get(absolutePath.toUri(), absolutePath)
+            ?.getModule()
+            ?.get()
         }
         // targetUri is a relative URI
         null -> {


### PR DESCRIPTION
This aims to resolve #91.

This is a rudementary implementation to figure out, what direction this feature should go.
It looks for a `.pkl-module-path` file in the workspacefolders, reads it, and interpretes ever line that is neither blank nor starts with a `#` (to allow comments) as a `modulepath` entry.

Currently this happens _every time_ an import is resolved. Hence Invalid and non-existent entries are ignored at the moment to not flood the logs. A better way would probably be to use the `CachedValuesManager` with a `dependency` either to the `FsFile` or an lsp event signaling its creation. Alternatively it could load it just once at startup.

Also, is a `.pkl-module-path` file appropriate or should it be more general for lsp settings?