### PR TITLE
Check for NonNull in diagnostics and type checks

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklBaseModule.kt
@@ -63,6 +63,7 @@ class PklBaseModule(project: Project) : Component(project) {
 
   val anyType: Type.Class = classType("Any")
   val nullType: Type.Class = classType("Null")
+  val nonNullType: Type.Alias = aliasType("NonNull")
   val booleanType: Type.Class = classType("Boolean")
   val numberType: Type.Class = classType("Number")
   val intType: Type.Class = classType("Int")

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ExprAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ExprAnalyzer.kt
@@ -36,7 +36,7 @@ class ExprAnalyzer(project: Project) : Analyzer(project) {
         if (testedType.hasConstraints) return false
         // can't use subtype relationship to check NonNull
         if (testedType.isNonNull(base)) {
-          if (!exprType.isNullable(base, context)) {
+          if (!exprType.isNullable(base, context) || exprType.isNonNull(base)) {
             diagnosticsHolder.addWarning(node, ErrorMessages.create("expressionIsAlwaysTrue"))
           }
         } else {

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -224,6 +224,8 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
   fun isNullable(base: PklBaseModule, context: PklProject?): Boolean =
     base.nullType.isSubtypeOf(this, base, context)
 
+  fun isNonNull(base: PklBaseModule): Boolean = this is Alias && ctx == base.nonNullType.ctx
+
   fun isAmendable(base: PklBaseModule, context: PklProject?): Boolean =
     amended(base, context) != Nothing
 

--- a/src/test/files/DiagnosticsSnippetTests/inputs/expr/alwaysTrueOrFalse.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/expr/alwaysTrueOrFalse.pkl
@@ -2,16 +2,12 @@ foo = 1 is Number
 
 bar = 1 is Boolean
 
-baz: String
+baz = "bar" is NonNull
 
 bazNullable: String?
 
-obj {
-  when (baz is NonNull) {
-    baz
-  }
-  // no warning
-  when (bazNullable is NonNull) {
-    bazNullable
-  }
-}
+checkBaz = bazNullable is NonNull
+
+nonNull: NonNull
+
+checkNonNull = nonNull is NonNull

--- a/src/test/files/DiagnosticsSnippetTests/inputs/expr/alwaysTrueOrFalse.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/expr/alwaysTrueOrFalse.pkl
@@ -1,3 +1,17 @@
 foo = 1 is Number
 
 bar = 1 is Boolean
+
+baz: String
+
+bazNullable: String?
+
+obj {
+  when (baz is NonNull) {
+    baz
+  }
+  // no warning
+  when (bazNullable is NonNull) {
+    bazNullable
+  }
+}

--- a/src/test/files/DiagnosticsSnippetTests/outputs/expr/alwaysTrueOrFalse.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/expr/alwaysTrueOrFalse.txt
@@ -6,3 +6,18 @@
        ^^^^^^^^^^^^
 | Warning: Expression is always 'false'
  
+ baz: String
+ 
+ bazNullable: String?
+ 
+ obj {
+   when (baz is NonNull) {
+         ^^^^^^^^^^^^^^
+| Warning: Expression is always 'true'
+     baz
+   }
+   // no warning
+   when (bazNullable is NonNull) {
+     bazNullable
+   }
+ }

--- a/src/test/files/DiagnosticsSnippetTests/outputs/expr/alwaysTrueOrFalse.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/expr/alwaysTrueOrFalse.txt
@@ -6,18 +6,16 @@
        ^^^^^^^^^^^^
 | Warning: Expression is always 'false'
  
- baz: String
+ baz = "bar" is NonNull
+       ^^^^^^^^^^^^^^^^
+| Warning: Expression is always 'true'
  
  bazNullable: String?
  
- obj {
-   when (baz is NonNull) {
-         ^^^^^^^^^^^^^^
+ checkBaz = bazNullable is NonNull
+ 
+ nonNull: NonNull
+ 
+ checkNonNull = nonNull is NonNull
+                ^^^^^^^^^^^^^^^^^^
 | Warning: Expression is always 'true'
-     baz
-   }
-   // no warning
-   when (bazNullable is NonNull) {
-     bazNullable
-   }
- }


### PR DESCRIPTION
Because we only check subtype and some constraints relationship, a wrong warning would show
when comparing things to `NonNull`.
```pkl
myOptionalThing: String?

thingsThatAre: Listing<String> = new {
  // this was showing: Expression is always true
  when(myOptionalThing is NonNull) {
    myOptionalThing
  }
}
```

Even though this is not idiomatic Pkl (one should use `??` or compare something to `null` directly) we shouldn't show a wrong warning.