### PR TITLE
Prevent union type simplification from ignoring constraints

### DIFF
--- a/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/unions.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/unions.pkl
@@ -2,3 +2,17 @@ foo: Int|String = true
 
 bar: Int = null
 
+class Expr
+typealias Expression = Expr|String(startsWith("!"))
+
+class A {
+  username: String|Expression
+}
+
+// none of these should have diags
+a = new A {
+  username = "admin"
+}
+b = new A {
+  username = "!foo"
+}

--- a/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/unions.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/unions.txt
@@ -10,4 +10,18 @@
 | Required: Int
 | Actual: Null
  
+ class Expr
+ typealias Expression = Expr|String(startsWith("!"))
+ 
+ class A {
+   username: String|Expression
+ }
+ 
+ // none of these should have diags
+ a = new A {
+   username = "admin"
+ }
+ b = new A {
+   username = "!foo"
+ }
  


### PR DESCRIPTION
Another shot at fixing https://github.com/apple/pkl-intellij/issues/91

The union type simplification logic previously made bad assumptions when comparing constraints. This PR extends subtype check to allow strictly accounting for constraints, but does not change the logic for other callers performing subtype checks.