### PR TITLE
Fix inferred import names not quoting keywords

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/AccessExprAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/AccessExprAnalyzer.kt
@@ -248,7 +248,7 @@ class AccessExprAnalyzer(project: Project) : Analyzer(project) {
     // scenario 1: this is a reference from a const property, and can only reference other const
     // properties
     if (isConst) {
-      val name = node.identifier!!.text
+      val name = node.identifierName!!
       val action = if (target is PklProperty) "reference property" else "call method"
       val message = ErrorMessages.create("cannotAccessFromConst", action, name)
       holder.addError(node, message, span = node.identifier!!.span)

--- a/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Expr.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -171,7 +171,7 @@ class PklUnqualifiedAccessExprImpl(
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklUnqualifiedAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
-  override val memberNameText: String by lazy { identifier!!.text }
+  override val memberNameText: String by lazy { identifierName!! }
   override val argumentList: PklArgumentList? by lazy {
     children.firstInstanceOf<PklArgumentList>()
   }
@@ -282,7 +282,7 @@ class PklSuperAccessExprImpl(
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklSuperAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
-  override val memberNameText: String by lazy { identifier!!.text }
+  override val memberNameText: String by lazy { identifierName!! }
   override val isNullSafeAccess: Boolean = false
   override val argumentList: PklArgumentList? by lazy {
     children.firstInstanceOf<PklArgumentList>()
@@ -329,7 +329,7 @@ class PklQualifiedAccessExprImpl(
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklQualifiedAccessExpr {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
-  override val memberNameText: String by lazy { identifier!!.text }
+  override val memberNameText: String by lazy { identifierName!! }
   override val isNullSafeAccess: Boolean by lazy {
     terminals.find { it.type == TokenType.QDOT } != null
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -226,17 +226,17 @@ val PklImport.memberName: String?
         ?.stringConstant
         ?.escapedText()
         ?.let { inferImportPropertyName(it) }
-        ?.let { if (shouldQuoteIdentifier(it)) "`$it`" else it }
+        ?.let { if (isRegularIdentifier(it)) it else "`$it`" }
 
-private fun shouldQuoteIdentifier(identifier: String): Boolean {
-  if (identifier.isEmpty()) return true
-  if (identifier in KEYWORDS) return true
+private fun isRegularIdentifier(identifier: String): Boolean {
+  if (identifier.isEmpty()) return false
+  if (identifier in KEYWORDS) return false
 
   val firstCp = identifier.codePointAt(0)
   if (firstCp != '$'.code && firstCp != '_'.code && !Character.isUnicodeIdentifierStart(firstCp))
-    return true
+    return false
 
-  return !identifier.codePoints().skip(1).allMatch { cp ->
+  return identifier.codePoints().skip(1).allMatch { cp ->
     cp == '$'.code || Character.isUnicodeIdentifierPart(cp)
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -38,6 +38,53 @@ import org.pkl.lsp.type.computeResolvedImportType
 import org.pkl.lsp.type.toType
 import org.pkl.lsp.util.ModificationTracker
 
+private val KEYWORDS =
+  setOf(
+    "_",
+    "abstract",
+    "amends",
+    "as",
+    "case",
+    "class",
+    "const",
+    "delete",
+    "else",
+    "extends",
+    "external",
+    "false",
+    "fixed",
+    "for",
+    "function",
+    "hidden",
+    "if",
+    "import",
+    "in",
+    "is",
+    "let",
+    "local",
+    "module",
+    "new",
+    "nothing",
+    "null",
+    "open",
+    "out",
+    "outer",
+    "override",
+    "protected",
+    "read",
+    "record",
+    "super",
+    "switch",
+    "this",
+    "throw",
+    "trace",
+    "true",
+    "typealias",
+    "unknown",
+    "vararg",
+    "when",
+  )
+
 val PklClass.supertype: PklType?
   get() = extends
 
@@ -175,7 +222,24 @@ fun PklClass.hasCommonSubclassWith(other: PklClass, context: PklProject?): Boole
 val PklImport.memberName: String?
   get() =
     identifier?.text
-      ?: moduleUri?.stringConstant?.escapedText()?.let { inferImportPropertyName(it) }
+      ?: moduleUri
+        ?.stringConstant
+        ?.escapedText()
+        ?.let { inferImportPropertyName(it) }
+        ?.let { if (shouldQuoteIdentifier(it)) "`$it`" else it }
+
+private fun shouldQuoteIdentifier(identifier: String): Boolean {
+  if (identifier.isEmpty()) return true
+  if (identifier in KEYWORDS) return true
+
+  val firstCp = identifier.codePointAt(0)
+  if (firstCp != '$'.code && firstCp != '_'.code && !Character.isUnicodeIdentifierStart(firstCp))
+    return true
+
+  return !identifier.codePoints().skip(1).allMatch { cp ->
+    cp == '$'.code || Character.isUnicodeIdentifierPart(cp)
+  }
+}
 
 fun PklStringConstant.escapedText(): String? = getEscapedTextSl()
 

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -38,53 +38,6 @@ import org.pkl.lsp.type.computeResolvedImportType
 import org.pkl.lsp.type.toType
 import org.pkl.lsp.util.ModificationTracker
 
-private val KEYWORDS =
-  setOf(
-    "_",
-    "abstract",
-    "amends",
-    "as",
-    "case",
-    "class",
-    "const",
-    "delete",
-    "else",
-    "extends",
-    "external",
-    "false",
-    "fixed",
-    "for",
-    "function",
-    "hidden",
-    "if",
-    "import",
-    "in",
-    "is",
-    "let",
-    "local",
-    "module",
-    "new",
-    "nothing",
-    "null",
-    "open",
-    "out",
-    "outer",
-    "override",
-    "protected",
-    "read",
-    "record",
-    "super",
-    "switch",
-    "this",
-    "throw",
-    "trace",
-    "true",
-    "typealias",
-    "unknown",
-    "vararg",
-    "when",
-  )
-
 val PklClass.supertype: PklType?
   get() = extends
 
@@ -142,7 +95,7 @@ fun PklSimpleTypeName.resolve(context: PklProject?): PklNode? {
 
 fun PklModuleName.resolve(context: PklProject?): PklModule? {
   val module = enclosingModule ?: return null
-  val moduleNameText = identifier!!.text
+  val moduleNameText = identifierName!!
   for (import in module.imports) {
     if (import.memberName == moduleNameText) {
       val resolved = import.resolve(context) as? SimpleModuleResolutionResult ?: return null
@@ -221,25 +174,7 @@ fun PklClass.hasCommonSubclassWith(other: PklClass, context: PklProject?): Boole
 
 val PklImport.memberName: String?
   get() =
-    identifier?.text
-      ?: moduleUri
-        ?.stringConstant
-        ?.escapedText()
-        ?.let { inferImportPropertyName(it) }
-        ?.let { if (isRegularIdentifier(it)) it else "`$it`" }
-
-private fun isRegularIdentifier(identifier: String): Boolean {
-  if (identifier.isEmpty()) return false
-  if (identifier in KEYWORDS) return false
-
-  val firstCp = identifier.codePointAt(0)
-  if (firstCp != '$'.code && firstCp != '_'.code && !Character.isUnicodeIdentifierStart(firstCp))
-    return false
-
-  return identifier.codePoints().skip(1).allMatch { cp ->
-    cp == '$'.code || Character.isUnicodeIdentifierPart(cp)
-  }
-}
+    identifierName ?: moduleUri?.stringConstant?.escapedText()?.let { inferImportPropertyName(it) }
 
 fun PklStringConstant.escapedText(): String? = getEscapedTextSl()
 

--- a/src/main/kotlin/org/pkl/lsp/ast/Member.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Member.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,7 +47,7 @@ class PklClassPropertyImpl(
   // TODO: in tree-sitter this has multiple bodies
   override val objectBody: PklObjectBody? by lazy { getChild(PklObjectBodyImpl::class) }
 
-  override val name: String by lazy { identifier!!.text }
+  override val name: String by lazy { identifierName!! }
 
   override val type: PklType? by lazy { typeAnnotation?.type }
 
@@ -127,7 +127,7 @@ class PklClassMethodImpl(
 
   override val methodHeader: PklMethodHeader by lazy { getChild(PklMethodHeaderImpl::class)!! }
 
-  override val name: String by lazy { methodHeader.identifier!!.text }
+  override val name: String by lazy { methodHeader.identifierName!! }
 
   override val modifiers: List<Terminal>? by lazy { methodHeader.modifiers }
 
@@ -247,7 +247,7 @@ class PklObjectPropertyImpl(
 ) : AbstractPklNode(project, parent, ctx), PklObjectProperty {
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
   override val modifiers: List<Terminal> by lazy { terminals.filter { it.isModifier } }
-  override val name: String by lazy { identifier!!.text }
+  override val name: String by lazy { identifierName!! }
   override val type: PklType? by lazy { typeAnnotation?.type }
   override val expr: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
   override val typeAnnotation: PklTypeAnnotation? by lazy {
@@ -283,7 +283,7 @@ class PklObjectMethodImpl(
   override val methodHeader: PklMethodHeader by lazy { getChild(PklMethodHeaderImpl::class)!! }
   override val modifiers: List<Terminal>? by lazy { methodHeader.modifiers }
   override val body: PklExpr? by lazy { children.firstInstanceOf<PklExpr>() }
-  override val name: String by lazy { methodHeader.identifier!!.text }
+  override val name: String by lazy { methodHeader.identifierName!! }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitObjectMethod(this)

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -244,7 +244,7 @@ class PklClassImpl(
 
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
 
-  override val name: String by lazy { identifier!!.text }
+  override val name: String by lazy { identifierName!! }
 
   override val modifiers: List<Terminal>? by lazy { terminals.filter { it.isModifier } }
 

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -118,6 +118,13 @@ interface PklStringConstant : PklNode {
 interface IdentifierOwner : PklNode {
   val identifier: Terminal?
 
+  val identifierName: String?
+    get() =
+      identifier?.let { node ->
+        val text = node.text
+        if (text.startsWith("`")) text.substring(1, text.length - 1) else text
+      }
+
   fun matches(line: Int, col: Int): Boolean = identifier?.span?.matches(line, col) == true
 }
 

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -181,7 +181,7 @@ class PklTypeAliasImpl(project: Project, override val parent: PklNode?, ctx: Nod
   AbstractPklNode(project, parent, ctx), PklTypeAlias {
   override val modifiers: List<Terminal>? by lazy { terminals.filter { it.isModifier } }
   override val identifier: Terminal? by lazy { terminals.find { it.type == TokenType.Identifier } }
-  override val name: String by lazy { identifier!!.text }
+  override val name: String by lazy { identifierName!! }
   override val type: PklType by lazy { children.firstInstanceOf<PklType>()!! }
 
   override fun isRecursive(context: PklProject?): Boolean = isRecursive(mutableSetOf(), context)

--- a/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
+++ b/src/main/kotlin/org/pkl/lsp/resolvers/Resolvers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,7 +202,7 @@ object Resolvers {
     if (this == null) return true
 
     for (parameter in typeParameters) {
-      val parameterName = parameter.identifier!!.text
+      val parameterName = parameter.identifierName!!
       if (!visitor.visit(parameterName, parameter, bindings, context)) return false
     }
 

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1172,7 +1172,7 @@ fun PklType?.toType(
       val simpleName = name.simpleTypeName
       when (val resolved = simpleName.resolve(context)) {
         null -> Type.Unknown
-        is PklModule -> Type.module(resolved, simpleName.identifier!!.text, context)
+        is PklModule -> Type.module(resolved, simpleName.identifierName!!, context)
         is PklClass -> {
           val typeArguments = this.typeArgumentList?.types ?: listOf()
           Type.Class(

--- a/src/test/files/DiagnosticsSnippetTests/inputHelpers/accessExpr/module.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputHelpers/accessExpr/module.pkl
@@ -1,0 +1,3 @@
+module `module`
+
+bar: Int = 1

--- a/src/test/files/DiagnosticsSnippetTests/inputs/accessExpr/keywordNamedImport.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/accessExpr/keywordNamedImport.pkl
@@ -1,0 +1,5 @@
+import ".../inputHelpers/accessExpr/module.pkl"
+
+foo = `module`.bar
+
+bar = `module`.foo

--- a/src/test/files/DiagnosticsSnippetTests/outputs/accessExpr/keywordNamedImport.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/accessExpr/keywordNamedImport.txt
@@ -1,0 +1,8 @@
+ import ".../inputHelpers/accessExpr/module.pkl"
+ 
+ foo = `module`.bar
+ 
+ bar = `module`.foo
+                ^^^
+| Error: Unresolved reference `foo`
+ 

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
@@ -537,4 +537,52 @@ class GoToDefinitionTest : LspTestBase() {
     val resolved = goToDefinition()
     assertThat(resolved).isEmpty()
   }
+
+  @Test
+  fun `resolve backtick names -- module keyword`() {
+    val modulePklFile = createPklFile("module.pkl", "")
+    createPklFile(
+      """
+      import "module.pkl"
+      
+      res = `module`<caret>
+      """
+        .trimIndent()
+    )
+    val resolved = goToDefinition()
+    assertThat(resolved[0]).isInstanceOf(PklModule::class.java)
+    val resolvedFile = resolved.first().containingFile
+    assertThat(Path.of(resolvedFile.uri).absolutePathString())
+      .isEqualTo(modulePklFile.absolutePathString())
+  }
+
+  @Test
+  fun `resolve backtick names -- quoted identifiers are same as unquoted`() {
+    createPklFile(
+      """
+      foo = 1
+      
+      res = `foo`<caret>
+    """
+        .trimIndent()
+    )
+
+    val resolved = goToDefinition()
+    assertThat(resolved.first()).isInstanceOf(PklClassProperty::class.java)
+  }
+
+  @Test
+  fun `resolve backtick names -- quoted identifiers are same as unquoted 2`() {
+    createPklFile(
+      """
+      `foo` = 1
+      
+      res = foo<caret>
+    """
+        .trimIndent()
+    )
+
+    val resolved = goToDefinition()
+    assertThat(resolved.first()).isInstanceOf(PklClassProperty::class.java)
+  }
 }


### PR DESCRIPTION
Closes #139

I took the list of keywords from [here](https://github.com/apple/pkl/blob/main/pkl-parser/src/main/java/org/pkl/parser/Lexer.java#L776) and copied the logic for when to quote identifieres from [here](https://github.com/apple/pkl/blob/main/pkl-parser/src/main/java/org/pkl/parser/Lexer.java#L768).