### PR TITLE
SPICE-0028: Add support for multi-line string line continuations

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,8 @@ pkl = "0.31.0"
 shadowPlugin = "9.2.2"
 spotless = "6.25.0"
 treeSitterRepo = "v0.25.3" # git tag name
-treeSitterPklRepo = "v0.20.0" # git tag name
+treeSitterPklRepo = "f9405e40597d7dac637a6b49e7d26c4515cb2a34" # TODO: switch to tag once released
+#treeSitterPklRepo = "v0.21.0" # git tag name
 zig = "0.13.0" # used for cross-compiling tree-sitter libs
 
 # Only need checksums for distributions that we might run builds on.

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ val PklImport.memberName: String?
     identifier?.text
       ?: moduleUri?.stringConstant?.escapedText()?.let { inferImportPropertyName(it) }
 
-fun PklStringConstant.escapedText(): String? = getEscapedText()
+fun PklStringConstant.escapedText(): String? = getEscapedTextSl()
 
 fun PklStringLiteral.escapedText(): String? =
   when (this) {
@@ -185,44 +185,71 @@ fun PklStringLiteral.escapedText(): String? =
     is PklMultiLineStringLiteral -> escapedText()
   }
 
-fun PklSingleLineStringLiteral.escapedText(): String? =
-  if (exprs.isEmpty()) getEscapedText() else null
+private fun PklSingleLineStringLiteral.escapedText(): String? =
+  if (!exprs.isEmpty()) null else getEscapedTextSl()
 
-fun PklMultiLineStringLiteral.escapedText(): String? =
-  if (exprs.isEmpty()) getEscapedText() else null
-
-private fun PklNode.getEscapedText(): String? = buildString {
+private fun PklNode.getEscapedTextSl(): String? = buildString {
   for (terminal in terminals) {
     when (terminal.type) {
       TokenType.SLQuote,
-      TokenType.SLEndQuote,
-      TokenType.MLQuote,
-      TokenType.MLEndQuote -> {} // ignore open/close quotes
-      TokenType.SLCharacters,
-      TokenType.MLCharacters -> append(terminal.text)
-      TokenType.CharacterEscape -> {
-        val text = terminal.text
-        if (text.contains("u{")) {
-          val index = text.indexOf('{') + 1
-          val hexString = text.substring(index, text.length - 1)
-          try {
-            append(Character.toChars(Integer.parseInt(hexString, 16)))
-          } catch (ignored: NumberFormatException) {} catch (ignored: IllegalArgumentException) {}
-        } else {
-          when (text[text.lastIndex]) {
-            'n' -> append('\n')
-            'r' -> append('\r')
-            't' -> append('\t')
-            '\\' -> append('\\')
-            '"' -> append('"')
-            else -> throw AssertionError("Unknown char escape: $text")
-          }
-        }
-      }
-      TokenType.MLNewline -> append('\n')
+      TokenType.SLEndQuote -> {} // ignore open/close quotes
+      TokenType.SLCharacters -> append(terminal.text)
+      TokenType.CharacterEscape -> appendEscape(terminal)
       else ->
         // interpolated or invalid string -> bail out
         return null
+    }
+  }
+}
+
+private fun PklMultiLineStringLiteral.escapedText(): String? =
+  if (!exprs.isEmpty()) null
+  else
+    buildString {
+        // assumes lines can only end in \n (or \r\n)
+        val mlPrefix = terminals.dropLast(1).last().text.takeLastWhile { it != '\n' }
+        var afterContinuation = false
+        for ((idx, terminal) in terminals.withIndex()) {
+          when (terminal.type) {
+            TokenType.MLQuote,
+            TokenType.MLEndQuote -> {} // ignore open/close quotes
+            TokenType.MLCharacters -> {
+              var text = terminal.text
+              if (idx == 1) text = text.removePrefix("\n$mlPrefix") // MLQuote is idx 0
+              else if (afterContinuation) {
+                text = text.removePrefix(mlPrefix)
+                afterContinuation = false
+              }
+              text = text.replace("\n$mlPrefix", "\n")
+              append(text)
+            }
+            TokenType.CharacterEscape -> appendEscape(terminal)
+            TokenType.MLNewline -> append('\n')
+            TokenType.StringContinuation -> afterContinuation = true
+            else ->
+              // interpolated or invalid string -> bail out
+              return null
+          }
+        }
+      }
+      .removeSuffix("\n")
+
+private fun Appendable.appendEscape(terminal: Terminal) {
+  val text = terminal.text
+  if (text.contains("u{")) {
+    val index = text.indexOf('{') + 1
+    val hexString = text.substring(index, text.length - 1)
+    try {
+      append(Character.toChars(Integer.parseInt(hexString, 16)).concatToString())
+    } catch (_: NumberFormatException) {} catch (_: IllegalArgumentException) {}
+  } else {
+    when (text[text.lastIndex]) {
+      'n' -> append('\n')
+      'r' -> append('\r')
+      't' -> append('\t')
+      '\\' -> append('\\')
+      '"' -> append('"')
+      else -> throw AssertionError("Unknown char escape: $text")
     }
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -942,6 +942,7 @@ fun Node.toNode(project: Project, parent: PklNode?): PklNode? {
     "identifier" -> toTerminal(parent!!)
     "docComment" -> toTerminal(parent!!)
     "escapeSequence" -> toTerminal(parent!!)
+    "mlStringContinuation" -> toTerminal(parent!!)
     // just becomes an expression
     "stringInterpolation" -> children[1].toNode(project, parent)
     "lineComment" -> PklLineCommentImpl(project, parent!!, this)

--- a/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Terminal.kt
@@ -152,6 +152,7 @@ fun Node.toTerminal(parent: PklNode): Terminal? {
       "identifier" -> TokenType.Identifier
       "docComment" -> TokenType.DocComment
       "escapeSequence" -> TokenType.CharacterEscape
+      "mlStringContinuation" -> TokenType.StringContinuation
       "\\(" -> TokenType.InterpolationStart
       "\\#(" -> TokenType.InterpolationStart
       "\\##(" -> TokenType.InterpolationStart

--- a/src/main/kotlin/org/pkl/lsp/ast/TokenType.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/TokenType.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,7 @@ enum class TokenType {
   SLEndQuote,
   SLInterpolation,
   CharacterEscape,
+  StringContinuation,
   SLCharacters,
   MLEndQuote,
   MLInterpolation,

--- a/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/constraints.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/typecheck/constraints.pkl
@@ -63,3 +63,13 @@ listing1 = new Listing<MyStr> {
 listing2: Listing<MyStr> = new {
   "Invalid"
 }
+
+mlString1: String(this == "hello\nworld") = """
+  hello
+  world
+  """
+
+mlString1: String(this == "hello world") = """
+  hello \
+  world
+  """

--- a/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/constraints.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/typecheck/constraints.txt
@@ -183,3 +183,14 @@
 | Required: matches(Regex(#"\d*"#))
 | Found: "Invalid"
  }
+ 
+ mlString1: String(this == "hello\nworld") = """
+   hello
+   world
+   """
+ 
+ mlString1: String(this == "hello world") = """
+   hello \
+   world
+   """
+ 

--- a/src/test/files/ParserSnippetTests/inputs/expr/strings.pkl
+++ b/src/test/files/ParserSnippetTests/inputs/expr/strings.pkl
@@ -1,2 +1,6 @@
 res1 = "one"
 res2 = "// one"
+res3 = """
+  hello \
+  world
+  """

--- a/src/test/files/ParserSnippetTests/outputs/expr/strings.txt
+++ b/src/test/files/ParserSnippetTests/outputs/expr/strings.txt
@@ -3,3 +3,5 @@ PklModuleImpl
     PklSingleLineStringLiteralImpl
   PklClassPropertyImpl
     PklSingleLineStringLiteralImpl
+  PklClassPropertyImpl
+    PklMultiLineStringLiteralImpl

--- a/src/test/kotlin/org/pkl/lsp/ParserTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/ParserTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,6 +63,37 @@ class ParserTest {
     val strLiteral2 = mod.children[1].children[2]
     assertThat(strLiteral2).isInstanceOf(PklSingleLineStringLiteral::class.java)
     strLiteral2 as PklSingleLineStringLiteral
+    assertThat(strLiteral2.escapedText()).isNull()
+  }
+
+  @Test
+  fun `parse multiline strings`() {
+    val code =
+      """
+      foo = ${'"'}""
+        
+         hello \
+        world
+        
+        xyz
+        
+        ${'"'}""
+      bar = ${'"'}""
+        hello \
+        \(inter)
+        ${'"'}""
+    """
+        .trimIndent()
+
+    val mod = parse(code)
+    val strLiteral = mod.children[0].children[2]
+    assertThat(strLiteral).isInstanceOf(PklMultiLineStringLiteral::class.java)
+    strLiteral as PklMultiLineStringLiteral
+    assertThat(strLiteral.escapedText()).isEqualTo("\n hello world\n\nxyz\n")
+
+    val strLiteral2 = mod.children[1].children[2]
+    assertThat(strLiteral2).isInstanceOf(PklMultiLineStringLiteral::class.java)
+    strLiteral2 as PklMultiLineStringLiteral
     assertThat(strLiteral2.escapedText()).isNull()
   }
 


### PR DESCRIPTION
This also fixes a bug where multi-line string contents were not calculated correctly.

Blocked on merge+release of https://github.com/apple/tree-sitter-pkl/pull/69