### PR TITLE
Add Dependabot updates for Gradle, CodeQL scanning

### DIFF
--- a/.github/PklProject
+++ b/.github/PklProject
@@ -18,7 +18,7 @@ amends "pkl:Project"
 
 dependencies {
   ["pkl.impl.ghactions"] {
-    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0"
+    uri = "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.0"
   }
   ["com.github.actions"] {
     uri = "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.0"

--- a/.github/PklProject.deps.json
+++ b/.github/PklProject.deps.json
@@ -3,16 +3,16 @@
   "resolvedDependencies": {
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.3.1",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.actions@1.6.0",
       "checksums": {
-        "sha256": "fd515da685ea126678c3ec684e84a4f992d43481cc1d75cb866cd55775f675f9"
+        "sha256": "10e27d63df4a4520d8a9375962406ca5ffe74f396bd3cb1c19b1f8358505010a"
       }
     },
     "package://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.5.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-project-commons/pkl.impl.ghactions@1.7.0",
       "checksums": {
-        "sha256": "2c1e0d9efcd65b3c3207bf535c325ebc0ec2ab169187b324c4bb70821cac0e51"
+        "sha256": "962cdba703b50e86ecfda1a1345bf58caa7b4839dd090eae6120024d862793d0"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.experimental.deepToTyped@1": {
@@ -24,16 +24,16 @@
     },
     "package://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.0.3",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/pkl.github.dependabotManagedActions@1.1.3",
       "checksums": {
-        "sha256": "d368900942efb88ed51a98f9614748b06c74ba43423f045fcd6dedb5dbdc0bea"
+        "sha256": "521feb6f5ff12075ebad0758799fe7ec2675d231a0e0f5456694c8d4822a8171"
       }
     },
     "package://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1": {
       "type": "remote",
-      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.0",
+      "uri": "projectpackage://pkg.pkl-lang.org/pkl-pantry/com.github.dependabot@1.0.3",
       "checksums": {
-        "sha256": "02ef6f25bfca5b1d095db73ea15de79d2d2c6832ebcab61e6aba90554382abcb"
+        "sha256": "a8934d84ffd11992d7baf6acfd97bae31d6112fa8add5cc8b5b4a722ce5b9ffc"
       }
     }
   }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,14 @@
 version: 2
 updates:
+- package-ecosystem: gradle
+  cooldown:
+    default-days: 7
+  directory: /
+  schedule:
+    interval: weekly
 - package-ecosystem: github-actions
+  cooldown:
+    default-days: 7
   directory: /
   ignore:
   - dependency-name: '*'

--- a/.github/index.pkl
+++ b/.github/index.pkl
@@ -32,12 +32,6 @@ testReports {
   }
 }
 
-local buildAndTest: Workflow = new {
-  jobs {
-    ["build"] = buildJob(false)
-  }
-}
-
 local function buildJob(isRelease: Boolean): Workflow.Job = new {
   `runs-on` = "ubuntu-latest"
   steps {
@@ -225,6 +219,30 @@ release {
             """
         } |> helpers.withMavenPublishSecrets
       }
+    }
+  }
+}
+
+dependabot {
+  updates {
+    new {
+      `package-ecosystem` = "gradle"
+      directory = "/"
+      cooldown {
+        `default-days` = 7
+      }
+      schedule {
+        interval = "weekly"
+      }
+    }
+  }
+}
+
+codeql {
+  scans {
+    new {
+      language = "java-kotlin"
+      buildMode = "autobuild"
     }
   }
 }

--- a/.github/workflows/__lockfile__.yml
+++ b/.github/workflows/__lockfile__.yml
@@ -28,3 +28,7 @@ jobs:
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
     - name: dawidd6/action-download-artifact@v11
       uses: dawidd6/action-download-artifact@ac66b43f0e6a346234dd65d4d0c8fbb31cb316e5 # v11
+    - name: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+    - name: github/codeql-action/init@v4
+      uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+# Generated from Workflow.pkl. DO NOT EDIT.
+'on':
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+  schedule:
+  - cron: 29 17 * * 4
+jobs:
+  analyze-actions:
+    name: Analyze (actions)
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        languages: actions
+        build-mode: none
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        category: /language:actions
+  analyze-java-kotlin:
+    name: Analyze (java-kotlin)
+    permissions:
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        languages: java-kotlin
+        build-mode: autobuild
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4
+      with:
+        category: /language:java-kotlin

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ kotlin {
 
 tasks.withType<JavaCompile>().configureEach { options.release = buildInfo.jdkTargetVersion }
 
+configurations { all { resolutionStrategy { failOnDynamicVersions() } } }
+
 val pklCli: Configuration by configurations.creating
 
 val stagedShadowJar: Configuration by configurations.creating
@@ -93,6 +95,7 @@ dependencies {
   pklCli(
     "org.pkl-lang:pkl-cli-${buildInfo.os.canonicalName}-${buildInfo.arch.name}:${libs.versions.pkl.get()}"
   )
+  constraints { implementation(libs.gson) }
 }
 
 val configurePklCliExecutable by

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 assertj = "3.26.3"
 clikt = "5.0.1"
 downloadTaskPlugin = "5.6.0"
+gson = "2.13.2"
 jspecify = "1.0.0"
 jtreesitter = "0.25.0"
 junit = "5.11.3"
@@ -30,6 +31,7 @@ zigSha256-linux-aarch64 = "041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a
 assertJ = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }
 clikt = { group = "com.github.ajalt.clikt", name = "clikt", version.ref = "clikt" }
 downloadTaskPlugin = { group = "de.undercouch", name = "gradle-download-task", version.ref = "downloadTaskPlugin" }
+gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 jtreesitter = { group = "io.github.tree-sitter", name = "jtreesitter", version.ref = "jtreesitter" }
 junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }


### PR DESCRIPTION
Also, to make builds reproducible, make build fail on dynamic versions, and lock gson down to a specific version (this was failing).