### PR TITLE
Adjustments to modulepath logic

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -59,13 +59,6 @@ interface VirtualFile : ModificationTracker, CachedValueDataHolder {
   var version: Long?
 
   /**
-   * The root file of this VirtualFile's file system.
-   *
-   * May throw [OperationNotSupportedException] if this file cannot be converted to a [Path].
-   */
-  val root: VirtualFile?
-
-  /**
    * The NIO path backing this file.
    *
    * May throw [OperationNotSupportedException] if this file cannot be converted to a [Path].
@@ -80,6 +73,10 @@ interface VirtualFile : ModificationTracker, CachedValueDataHolder {
 
   /** Tells if this file is within a package. */
   val `package`: PackageDependency?
+
+  /** Tells if this file can possibly be on `modulepath` or not */
+  val isOnModulePath: Boolean
+    get() = false
 
   /** Tells if this file is a directory. */
   val isDirectory: Boolean
@@ -103,14 +100,11 @@ sealed class BaseFile : VirtualFile, CachedValueDataHolderBase() {
 
   override var version: Long? = null
 
-  final override val root: VirtualFile?
-    get() = project.virtualFileManager.get(path.root)
-
   abstract fun doReadContents(): String
 
   private var readError: Exception? = null
 
-  private val lock = Object()
+  private val lock = Any()
 
   // If contents have not yet been set, read contents from external source, possibly performing I/O.
   override var contents: String
@@ -158,11 +152,7 @@ sealed class BaseFile : VirtualFile, CachedValueDataHolderBase() {
   }
 }
 
-class FsFile(
-  override val path: Path,
-  override val project: Project,
-  val isOnModulepath: Boolean = false,
-) : BaseFile() {
+class FsFile(override val path: Path, override val project: Project) : BaseFile() {
   override val name: String = path.name
   override val uri: URI = path.toUri()
   override val pklAuthority: String = Origin.FILE.name.lowercase()
@@ -193,28 +183,30 @@ class FsFile(
     get() =
       when {
         !isDirectory -> null
-        isOnModulepath -> project.modulepathResolver.listChildren(path, null)
-        else -> path.listDirectoryEntries().mapNotNull(::getFile)
+        else -> project.modulepathResolver.listChildren(this)
       }
 
-  override fun parent(): VirtualFile? = path.parent?.let(::getFile)
+  override fun parent(): VirtualFile? = path.parent?.let { project.virtualFileManager.get(it) }
 
   override fun resolve(path: String): VirtualFile? {
-    val resolvedPath = this.path.resolve(path).normalize()
-    return if (Files.exists(resolvedPath))
-      project.virtualFileManager.get(resolvedPath.toUri(), resolvedPath)
-    else null
+    return when {
+      // prevent infinite recursion; otherwise calling `.resolve("PklProject")` will call
+      // `isOnModulePath`, which then
+      // calls `.resolve("PklProject")` again.
+      path == PKL_PROJECT_FILENAME -> project.virtualFileManager.get(this.path.resolve(path))
+      isOnModulePath -> project.modulepathResolver.resolve(this, path)
+      else -> project.virtualFileManager.get(this.path.resolve(path))
+    }
   }
+
+  override val isOnModulePath: Boolean
+    get() = project.modulepathResolver.isOnModulePath(this)
 
   override fun canModify(): Boolean = true
 
   override fun doReadContents(): String = path.readText()
 
-  private fun getFile(path: Path): VirtualFile? =
-    if (isOnModulepath) project.virtualFileManager.getModulepathFile(path)
-    else project.virtualFileManager.get(path)
-
-  private val lock = Object()
+  private val lock = Any()
 }
 
 class StdlibFile(moduleName: String, override val project: Project) : BaseFile() {
@@ -286,13 +278,9 @@ class HttpsFile(override val uri: URI, override val project: Project) : BaseFile
   override fun canModify(): Boolean = false
 }
 
-class JarFile(
-  override val path: Path,
-  override val uri: URI,
-  override val project: Project,
-  val isOnModulepath: Boolean = false,
-) : BaseFile() {
-  private val lock = Object()
+class JarFile(override val path: Path, override val uri: URI, override val project: Project) :
+  BaseFile() {
+  private val lock = Any()
 
   override val name: String
     get() = path.name
@@ -307,8 +295,7 @@ class JarFile(
     get() =
       when {
         !isDirectory -> null
-        isOnModulepath -> project.modulepathResolver.listChildren(path, null)
-        else -> path.listDirectoryEntries().mapNotNull(::getFile)
+        else -> project.modulepathResolver.listChildren(this)
       }
 
   override val `package`: PackageDependency?
@@ -324,13 +311,17 @@ class JarFile(
         CachedValue(packageUri.asPackageDependency(null))
       }
 
+  override val isOnModulePath: Boolean
+    get() = project.modulepathResolver.isOnModulePath(this)
+
   override val pklAuthority: String
     get() = Origin.JAR.name.lowercase()
 
   override fun parent(): VirtualFile? = path.parent?.let(::getFile)
 
   override fun resolve(path: String): VirtualFile? =
-    project.virtualFileManager.get(this.path.resolve(path))
+    if (isOnModulePath) project.modulepathResolver.resolve(this, path)
+    else project.virtualFileManager.get(this.path.resolve(path))
 
   override fun doReadContents(): String =
     project.cachedValuesManager.getCachedValue(
@@ -343,9 +334,7 @@ class JarFile(
 
   override fun canModify(): Boolean = false
 
-  private fun getFile(path: Path): VirtualFile? =
-    if (isOnModulepath) project.virtualFileManager.getModulepathFile(path)
-    else project.virtualFileManager.get(path)
+  private fun getFile(path: Path): VirtualFile? = project.virtualFileManager.get(path)
 }
 
 class EphemeralFile(private val text: String, override val project: Project) : BaseFile() {

--- a/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFileManager.kt
@@ -35,16 +35,9 @@ class VirtualFileManager(project: Project) : Component(project) {
     return create(effectiveUri, path)
   }
 
-  fun getFsFile(path: Path): FsFile? =
-    (if (project.modulepathResolver.isOnModulepath(path, null)) getModulepathFile(path)
-    else get(path))
-      as? FsFile
+  fun getFsFile(path: Path): FsFile? = get(path) as? FsFile
 
-  fun getFsFile(uri: URI): FsFile? =
-    (if (project.modulepathResolver.isOnModulepath(Path.of(uri), null))
-      getModulepathFile(Path.of(uri))
-    else get(uri))
-      as? FsFile
+  fun getFsFile(uri: URI): FsFile? = get(uri) as? FsFile
 
   fun getModulepathFile(path: Path): VirtualFile? {
     val jarUri = path.toUri()
@@ -57,12 +50,11 @@ class VirtualFileManager(project: Project) : Component(project) {
       when (jarUri?.scheme) {
         "jar" -> {
           ensureJarFileSystem(effectiveUri)
-          if (jarUri.toString().endsWith("!/"))
-            JarFile(path, jarUri, project, isOnModulepath = true)
-          else FsFile(path, project, isOnModulepath = true)
+          if (jarUri.toString().endsWith("!/")) JarFile(path, jarUri, project)
+          else FsFile(path, project)
         }
         else -> {
-          FsFile(path, project, isOnModulepath = true)
+          FsFile(path, project)
         }
       }
     return file.also { files[effectiveUri] = file }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -182,7 +182,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
         "file" -> {
           val listChildren = { it: VirtualFile -> it.children ?: emptyList() }
           val targetPath = targetUri.path ?: return null
-          return when {
+          when {
             targetPath.startsWith('/') -> {
               val fileRoot = project.virtualFileManager.getFsFile(Path.of("/")) ?: return null
               GlobResolver.resolveAbsoluteGlob(fileRoot, targetPath, isPartialUri, listChildren)
@@ -208,22 +208,6 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
                 isPartialUri,
                 listChildren,
               )
-          }
-        }
-
-        "modulepath" -> {
-          val listChildren = { it: VirtualFile -> it.children ?: emptyList() }
-          val targetPath = targetUri.path ?: return null
-          when {
-            targetPath.startsWith('/') -> {
-              val root = sourceFile.resolve("/") ?: return null
-              GlobResolver.resolveAbsoluteGlob(root, targetPath, isPartialUri, listChildren)
-            }
-
-            else -> {
-              val parent = sourceFile.parent() ?: return null
-              GlobResolver.resolveRelativeGlob(parent, targetUriString, isPartialUri, listChildren)
-            }
           }
         }
 

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -36,7 +36,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
 
   companion object {
 
-    private val lock = Object()
+    private val lock = Any()
 
     fun resolve(
       project: Project,
@@ -57,8 +57,10 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
                 if (nextPathSegment.isEmpty()) return null
                 ".../$nextPathSegment/.."
               }
+
               else -> return null
             }
+
           else -> targetUri
         }
 
@@ -104,14 +106,14 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
       return when (targetUri.scheme) {
         "pkl",
         "https" -> project.virtualFileManager.get(targetUri)?.getModule()?.get()
+
         "file" ->
           when {
             // be on the safe side and only follow file: URLs from local files
-            sourceFile is FsFile -> {
-              findByAbsolutePath(sourceFile, targetUri.path)?.getModule()?.get()
-            }
+            sourceFile is FsFile -> sourceFile.resolve(targetUri.path)?.getModule()?.get()
             else -> null
           }
+
         "package" -> {
           if (targetUri.fragment?.startsWith('/') != true) {
             return null
@@ -121,8 +123,12 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
               ?.resolve(targetUri.fragment)
           vfile?.getModule()?.get()
         }
+
         "modulepath" ->
-          project.modulepathResolver.resolveAbsolute(targetUri.path, context)?.getModule()?.get()
+          project.modulepathResolver
+            .resolveAbsolute(targetUri.path, sourceFile.pklProject)
+            ?.getModule()
+            ?.get()
         // targetUri is a relative URI
         null -> {
           when {
@@ -138,11 +144,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
                 root.resolve(resolvedTargetUri)?.getModule()?.get()
               } else null
             }
-            sourceFile is FsFile && sourceFile.isOnModulepath ->
-              project.modulepathResolver
-                .resolveRelative(sourceFile, targetUri.path, context)
-                ?.getModule()
-                ?.get()
+
             sourceFile is FsFile || sourceFile is JarFile ->
               findOnFileSystem(sourceFile, targetUri.path)?.getModule()?.get()
             // TODO: handle other types of relative uris
@@ -170,7 +172,11 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
       val targetUri = parseUriOrNull(targetUriString) ?: return null
       val project = sourceFile.project
 
-      val effectiveScheme = targetUri.scheme ?: sourceFile.uri.scheme
+      val effectiveScheme =
+        when {
+          sourceFile.isOnModulePath -> "modulepath"
+          else -> targetUri.scheme ?: sourceFile.uri.scheme
+        }
 
       return when (effectiveScheme) {
         "file" -> {
@@ -181,6 +187,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
               val fileRoot = project.virtualFileManager.getFsFile(Path.of("/")) ?: return null
               GlobResolver.resolveAbsoluteGlob(fileRoot, targetPath, isPartialUri, listChildren)
             }
+
             targetPath.startsWith('@') -> {
               getDependencyRoot(project, targetPath, element.enclosingModule, context)?.let { root
                 ->
@@ -193,6 +200,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
                 )
               }
             }
+
             else ->
               GlobResolver.resolveRelativeGlob(
                 parentDir,
@@ -202,6 +210,23 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
               )
           }
         }
+
+        "modulepath" -> {
+          val listChildren = { it: VirtualFile -> it.children ?: emptyList() }
+          val targetPath = targetUri.path ?: return null
+          when {
+            targetPath.startsWith('/') -> {
+              val root = sourceFile.resolve("/") ?: return null
+              GlobResolver.resolveAbsoluteGlob(root, targetPath, isPartialUri, listChildren)
+            }
+
+            else -> {
+              val parent = sourceFile.parent() ?: return null
+              GlobResolver.resolveRelativeGlob(parent, targetUriString, isPartialUri, listChildren)
+            }
+          }
+        }
+
         "package" -> {
           if (targetUri.fragment?.startsWith('/') != true) {
             return null
@@ -211,10 +236,9 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
               ?: return null
           val listChildren = { it: VirtualFile -> it.children ?: emptyList() }
           val targetPath = targetUri.fragment ?: return null
-          val resolved =
-            GlobResolver.resolveAbsoluteGlob(packageRoot, targetPath, isPartialUri, listChildren)
-          return resolved
+          GlobResolver.resolveAbsoluteGlob(packageRoot, targetPath, isPartialUri, listChildren)
         }
+
         else -> null
       }
     }
@@ -238,14 +262,8 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
     private fun findOnFileSystem(sourceFile: VirtualFile, targetPath: String): VirtualFile? {
       return when {
         targetPath.startsWith(".../") -> findTripleDotPathOnFileSystem(sourceFile, targetPath)
-        targetPath.startsWith("/") -> findByAbsolutePath(sourceFile, targetPath)
         else -> sourceFile.parent()?.resolve(targetPath)
       }
-    }
-
-    private fun findByAbsolutePath(sourceFile: VirtualFile, targetPath: String): VirtualFile? {
-      val path = Path.of(targetPath)
-      return sourceFile.project.virtualFileManager.get(path)
     }
 
     private fun findTripleDotPathOnFileSystem(

--- a/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
@@ -144,6 +144,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           )
         }
       }
+
       targetUri.startsWith(FILE_SCHEME) && !packageUriOnly -> {
         val roots = listOf(project.virtualFileManager.get(Path.of("/"))!!)
         completeHierarchicalUri(
@@ -157,6 +158,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           targetUri = targetUri,
         )
       }
+
       targetUri.startsWith(PACKAGE_SCHEME) -> {
         // if there is no fragment part, offer completions from the cached directory
         when (val packageAssetUri = PackageAssetUri.create(targetUri)) {
@@ -167,6 +169,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
               completePackageBaseUris(collector)
             }
           }
+
           else -> {
             val packageService = project.packageManager
             val libraryRoots =
@@ -185,6 +188,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           }
         }
       }
+
       targetUri.startsWith(MODULEPATH_SCHEME) -> {
         val context = sourceModule.virtualFile.pklProject
         val roots = project.modulepathResolver.paths(context)
@@ -199,6 +203,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           targetUri = targetUri,
         )
       }
+
       targetUri.startsWith("@") && !packageUriOnly -> {
         val dependencies = sourceModule.dependencies(null) ?: return
         if (!targetUri.contains('/')) {
@@ -234,6 +239,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
             }
         }
       }
+
       !targetUri.contains(':') && packageUriOnly -> {
         collector.add(
           CompletionItem().apply {
@@ -242,6 +248,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           }
         )
       }
+
       !targetUri.contains(':') -> {
         if (!targetUri.contains('/')) {
           collector.addAll(if (isGlobImport) GLOBBABLE_SCHEME_ELEMENTS else SCHEME_ELEMENTS)
@@ -334,7 +341,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
           val (targetPathDir, childMatch) =
             if (relativeTargetFilePath.endsWith("/")) relativeTargetFilePath to ""
             else
-              relativeTargetFilePath.substringBeforeLast('/') to
+              relativeTargetFilePath.substringBeforeLast('/', ".") to
                 relativeTargetFilePath.substringAfterLast('/')
           val resolved = sourceDir.resolve(targetPathDir) ?: return
           listOf(resolved) to childMatch
@@ -342,7 +349,7 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
 
       for (dir in dirs) {
         if (!dir.isDirectory) continue
-        dir.children!!.forEach { child ->
+        dir.children?.forEach { child ->
           if (!child.name.lowercase().startsWith(childMatch.lowercase()))
             return@forEach // FIXME: do a fuzzier match
           val isDirectory = child.isDirectory
@@ -433,21 +440,20 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
   ) {
     val sourceFile = sourceModule.virtualFile
     val sourceDir = sourceFile.parent() ?: return
-    val sourceRoot = sourceModule.virtualFile.path.root
+    val sourceRoot = sourceModule.virtualFile.resolve("/") ?: return
     val isAbsoluteTargetFilePath = targetUri.startsWith('/')
     val relativeTargetFilePath = if (isAbsoluteTargetFilePath) targetUri.drop(1) else targetUri
     if (isGlobImport && targetUri.startsWith("...")) {
       return
     }
-    val root = sourceModule.virtualFile.root ?: return
     val relativeSourceDirPath =
       if (isAbsoluteTargetFilePath) {
         "."
       } else {
-        sourceRoot.relativize(sourceDir.path).toString()
+        sourceRoot.path.relativize(sourceDir.path).toString()
       }
     completeHierarchicalUri(
-      listOf(root),
+      listOf(sourceRoot),
       relativeSourceDirPath,
       relativeTargetFilePath,
       collector,

--- a/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/ModuleUriCompletionProvider.kt
@@ -440,7 +440,15 @@ class ModuleUriCompletionProvider(project: Project, private val packageUriOnly: 
   ) {
     val sourceFile = sourceModule.virtualFile
     val sourceDir = sourceFile.parent() ?: return
-    val sourceRoot = sourceModule.virtualFile.resolve("/") ?: return
+    val sourceRoot =
+      if (sourceFile.isOnModulePath) {
+        val context = sourceFile.pklProject
+        project.modulepathResolver.paths(context).firstOrNull { root ->
+          sourceFile.path.startsWith(root.path)
+        } ?: return
+      } else {
+        sourceModule.virtualFile.resolve("/") ?: return
+      }
     val isAbsoluteTargetFilePath = targetUri.startsWith('/')
     val relativeTargetFilePath = if (isAbsoluteTargetFilePath) targetUri.drop(1) else targetUri
     if (isGlobImport && targetUri.startsWith("...")) {

--- a/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
@@ -20,10 +20,13 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.*
 import kotlin.io.path.*
 import org.pkl.lsp.Component
+import org.pkl.lsp.FsFile
+import org.pkl.lsp.JarFile
 import org.pkl.lsp.Project
 import org.pkl.lsp.VirtualFile
 import org.pkl.lsp.ensureJarFileSystem
 import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.util.CachedValue
 
 class ModulepathResolver(project: Project) : Component(project) {
 
@@ -32,11 +35,19 @@ class ModulepathResolver(project: Project) : Component(project) {
       "#!/bin/sh\n      exec java  -jar $0 \"$@\"".toByteArray(StandardCharsets.UTF_8)
   }
 
+  private val lock = Any()
+
   private fun modulepaths(context: PklProject?): List<Path> {
-    val paths =
-      context?.metadata?.evaluatorSettings?.modulePath?.map(context.projectDir::resolve)
-        ?: project.settingsManager.settings.modulepath
-    return paths.map(::normalizeArchivePath)
+    return project.cachedValuesManager.getCachedValue("modulepaths(${context?.projectDir})", lock) {
+      val modulePathFromPklProject =
+        context?.metadata?.evaluatorSettings?.modulePath?.map(context.projectDir::resolve).orEmpty()
+      val explicitlyConfiguredPath = project.settingsManager.settings.modulepath
+      val dependencies = listOf(project.pklProjectManager.syncTracker, project.settingsManager)
+      CachedValue(
+        (modulePathFromPklProject + explicitlyConfiguredPath).map(::normalizeArchivePath),
+        dependencies,
+      )
+    } ?: emptyList()
   }
 
   private fun normalizeArchivePath(path: Path): Path {
@@ -65,27 +76,39 @@ class ModulepathResolver(project: Project) : Component(project) {
     }
   }
 
-  private fun resolve(path: String, modulepath: List<Path>): VirtualFile? =
-    modulepath.map { it.resolve(path).normalize() }.firstOrNull(Files::exists)?.let(::getFile)
-
-  private fun getFile(path: Path): VirtualFile? = project.virtualFileManager.getModulepathFile(path)
-
-  fun resolveAbsolute(path: String, context: PklProject?): VirtualFile? =
-    resolve(path.trimStart('/'), modulepaths(context))
-
-  fun resolveRelative(sourceFile: VirtualFile, path: String, context: PklProject?): VirtualFile? {
-    val paths = modulepaths(context)
-    val root = paths.firstOrNull(sourceFile.path::startsWith) ?: return null
-    val relative =
-      runCatching { root.relativize(sourceFile.path.parent) }.getOrNull() ?: return null
-    return resolve(relative.resolve(path).normalize().toString(), paths)
+  fun resolveAbsolute(path: String, context: PklProject?): VirtualFile? {
+    assert(path.startsWith("/")) { "path is not an absolute path" }
+    val roots = modulepaths(context)
+    return roots.firstNotNullOfOrNull { root ->
+      project.virtualFileManager.get(root.resolve(path.drop(1)))
+    }
   }
+
+  fun resolve(file: VirtualFile, path: String): VirtualFile? {
+    assert(file.isOnModulePath) { "ModulepathResolver.resolve() called by file not on modulepath" }
+    val absolutePath =
+      when {
+        path.startsWith("/") -> path
+        else -> {
+          val roots = modulepaths(file.pklProject)
+          val myRoot = roots.first { file.path.startsWith(it) }
+          val myRelativePath = myRoot.relativize(file.path)
+          "/${myRelativePath.resolve(path)}"
+        }
+      }
+    return resolveAbsolute(absolutePath, file.pklProject)
+  }
+
+  private fun getFile(path: Path): VirtualFile? = project.virtualFileManager.get(path)
 
   fun paths(context: PklProject?): List<VirtualFile> = modulepaths(context).mapNotNull(::getFile)
 
-  fun listChildren(path: Path, context: PklProject?): List<VirtualFile> {
-    val paths = modulepaths(context)
-    println("modulepaths: $paths, startsWith: $path")
+  fun listChildren(file: VirtualFile): List<VirtualFile> {
+    if (!isOnModulePath(file)) {
+      return file.path.listDirectoryEntries().mapNotNull { project.virtualFileManager.get(it) }
+    }
+    val path = file.path
+    val paths = modulepaths(file.pklProject)
     val root = paths.firstOrNull(path::startsWith) ?: return emptyList()
     val relative = runCatching { root.relativize(path) }.getOrNull() ?: return emptyList()
     return paths
@@ -95,6 +118,9 @@ class ModulepathResolver(project: Project) : Component(project) {
       .mapNotNull(::getFile)
   }
 
-  fun isOnModulepath(path: Path, context: PklProject?): Boolean =
-    modulepaths(context).stream().anyMatch(path::startsWith)
+  fun isOnModulePath(file: VirtualFile): Boolean {
+    if (file !is FsFile && file !is JarFile) return false
+    val paths = modulepaths(file.pklProject)
+    return paths.any(file.path::startsWith)
+  }
 }

--- a/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
@@ -91,14 +91,15 @@ class ModulepathResolver(project: Project) : Component(project) {
         path.startsWith("/") -> path
         else -> {
           val roots = modulepaths(file.pklProject)
-          val myRelativePath = roots.firstNotNullOf { root ->
-            try {
-              val relativized = root.relativize(file.path)
-              if (relativized.startsWith("..")) null else relativized
-            } catch (_: IllegalArgumentException) {
-              null
+          val myRelativePath =
+            roots.firstNotNullOf { root ->
+              try {
+                val relativized = root.relativize(file.path)
+                if (relativized.startsWith("..")) null else relativized
+              } catch (_: IllegalArgumentException) {
+                null
+              }
             }
-          }
           "/${myRelativePath.resolve(path)}"
         }
       }

--- a/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
@@ -80,7 +80,7 @@ class ModulepathResolver(project: Project) : Component(project) {
     assert(path.startsWith("/")) { "path is not an absolute path" }
     val roots = modulepaths(context)
     return roots.firstNotNullOfOrNull { root ->
-      project.virtualFileManager.get(root.resolve(path.drop(1)))
+      project.virtualFileManager.get(root.resolve(path.drop(1)).normalize())
     }
   }
 

--- a/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/ModulepathResolver.kt
@@ -91,8 +91,14 @@ class ModulepathResolver(project: Project) : Component(project) {
         path.startsWith("/") -> path
         else -> {
           val roots = modulepaths(file.pklProject)
-          val myRoot = roots.first { file.path.startsWith(it) }
-          val myRelativePath = myRoot.relativize(file.path)
+          val myRelativePath = roots.firstNotNullOf { root ->
+            try {
+              val relativized = root.relativize(file.path)
+              if (relativized.startsWith("..")) null else relativized
+            } catch (_: IllegalArgumentException) {
+              null
+            }
+          }
           "/${myRelativePath.resolve(path)}"
         }
       }

--- a/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
@@ -19,14 +19,17 @@ import com.google.gson.JsonElement
 import com.google.gson.JsonPrimitive
 import java.net.URI
 import java.nio.file.Files
+import java.nio.file.InvalidPathException
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.atomic.AtomicInteger
 import kotlin.io.path.isExecutable
 import kotlinx.serialization.Serializable
 import org.eclipse.lsp4j.*
 import org.pkl.formatter.GrammarVersion
 import org.pkl.lsp.*
 import org.pkl.lsp.messages.ActionableNotification
+import org.pkl.lsp.util.ModificationTracker
 
 @Serializable
 data class WorkspaceSettings(
@@ -36,9 +39,10 @@ data class WorkspaceSettings(
   var excludedDirectories: List<String> = emptyList(),
 )
 
-class SettingsManager(project: Project) : Component(project) {
+class SettingsManager(project: Project) : Component(project), ModificationTracker {
   var settings: WorkspaceSettings = WorkspaceSettings()
   private lateinit var initialized: CompletableFuture<*>
+  private val updateCount = AtomicInteger(0)
 
   private val workspaceFolders: MutableSet<Path> = mutableSetOf()
 
@@ -96,9 +100,16 @@ class SettingsManager(project: Project) : Component(project) {
     return value.asJsonArray
       .mapNotNull { decodeString(it, "pkl.modulepath[]") }
       .mapNotNull { path ->
+        val resolvedPath =
+          try {
+            Path.of(path)
+          } catch (e: InvalidPathException) {
+            logger.warn("Configured module path $path is invalid: ${e.reason}")
+            return@mapNotNull null
+          }
         when {
-          path.startsWith("/") -> Path.of(path)
-          else -> workspaceFolders.map { it.resolve(path) }.firstOrNull(Files::exists)
+          resolvedPath.isAbsolute -> resolvedPath
+          else -> workspaceFolders.map { it.resolve(resolvedPath) }.firstOrNull(Files::exists)
         }
       }
   }
@@ -165,7 +176,10 @@ class SettingsManager(project: Project) : Component(project) {
           resolveExcludedDirectories(excludedDirectories as JsonElement)
       }
       .exceptionally { logger.error("Failed to fetch settings: ${it.cause}") }
-      .whenComplete { _, _ -> logger.log("Settings changed to $settings") }
+      .whenComplete { _, _ ->
+        logger.log("Settings changed to $settings")
+        updateCount.incrementAndGet()
+      }
   }
 
   private fun findPklCliOnPath(): Path? {
@@ -219,4 +233,6 @@ class SettingsManager(project: Project) : Component(project) {
     }
     initialized = loadSettings()
   }
+
+  override fun getModificationCount(): Long = updateCount.get().toLong()
 }

--- a/src/test/kotlin/org/pkl/lsp/CompletionFeatureTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/CompletionFeatureTest.kt
@@ -15,8 +15,10 @@
  */
 package org.pkl.lsp
 
+import java.nio.file.Path
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.pkl.lsp.completion.ModuleUriCompletionProvider.Companion.ModuleUriCompletionData
 
 class CompletionFeatureTest : LspTestBase() {
@@ -82,5 +84,26 @@ class CompletionFeatureTest : LspTestBase() {
     createPklFile("import \"modulepath:/dir/<caret>\"")
     val completions = getCompletions()
     assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
+  }
+
+  @Test
+  fun `complete absolute paths within modulepath`(@TempDir tempDir: Path) {
+    fakeProject.settingsManager.settings.modulepath = listOf(tempDir)
+    createPklFile(tempDir.resolve("bar.pkl").toString(), "bar = 1")
+    createPklFile(tempDir.resolve("foo.pkl").toString(), "import \"/<caret>\"")
+    val completions = getCompletions()
+    assertThat(completions.map { it.label }).isEqualTo(listOf("foo.pkl", "bar.pkl"))
+  }
+
+  @Test
+  fun `complete relative paths within modulepath`(
+    @TempDir tempDir1: Path,
+    @TempDir tempDir2: Path,
+  ) {
+    fakeProject.settingsManager.settings.modulepath = listOf(tempDir1, tempDir2)
+    createPklFile(tempDir1.resolve("bar/baz.pkl").toString(), "bar = 1")
+    createPklFile(tempDir2.resolve("bar/foo.pkl").toString(), "import \"./<caret>\"")
+    val completions = getCompletions()
+    assertThat(completions.map { it.label }).isEqualTo(listOf("baz.pkl", "foo.pkl"))
   }
 }

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -169,7 +169,7 @@ class SyncProjectsTest : LspTestBase() {
   }
 
   @Test
-  fun `project modulepath overrides lsp setting`() {
+  fun `project modulepath is combined with lsp setting`() {
     fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("foo"))
     createPklFile("foo/bar.pkl", "")
     createPklFile(
@@ -179,6 +179,9 @@ class SyncProjectsTest : LspTestBase() {
         .trimIndent()
     )
     val resolved = goToDefinition()
-    assertThat(resolved).isEmpty()
+    assertThat(resolved).hasSize(1)
+    assertThat(resolved[0]).isInstanceOf(PklModuleImpl::class.java)
+    val resolvedFile = resolved.first().containingFile
+    assertThat(resolvedFile.uri.schemeSpecificPart).endsWith("/foo/bar.pkl")
   }
 }


### PR DESCRIPTION
The following adjustments are made:

* `isOnModulepath` is removed as an instance field on `FsFile` and `JarFile`. Instead, `ModulePathResolver` keeps track of whether a dir is on the modulepath or not based on context (a directory may be on modulepath in the context of one PklProject, but not another).
* Add logic to resolve relative paths against `modulepath:` if it is configured as part of the modulepath (requires that you set this in configuration settings).
* modulePath declared in `PklProject.evaluatorSettings` is merged with explicitly configured settings

FYI @DrWursterich 