### PR TITLE
Fix compiler warning about parameter name mismatch

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
@@ -19,403 +19,403 @@ import org.pkl.lsp.ast.*
 
 open class PklVisitor<R> {
 
-  open fun visitAccessExpr(o: PklAccessExpr): R? {
-    return visitExpr(o)
+  open fun visitAccessExpr(node: PklAccessExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitAdditiveExpr(o: PklAdditiveExpr): R? {
-    return visitExpr(o)
+  open fun visitAdditiveExpr(node: PklAdditiveExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitAmendExpr(o: PklAmendExpr): R? {
-    return visitExpr(o)
+  open fun visitAmendExpr(node: PklAmendExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitAnnotation(o: PklAnnotation): R? {
-    return visitObjectBodyOwner(o)
+  open fun visitAnnotation(node: PklAnnotation): R? {
+    return visitObjectBodyOwner(node)
   }
 
-  open fun visitArgumentList(o: PklArgumentList): R? {
-    return visitElement(o)
+  open fun visitArgumentList(node: PklArgumentList): R? {
+    return visitElement(node)
   }
 
-  open fun visitClass(o: PklClass): R? {
-    return visitModuleMember(o)
+  open fun visitClass(node: PklClass): R? {
+    return visitModuleMember(node)
   }
 
-  open fun visitClassBody(o: PklClassBody): R? {
-    return visitElement(o)
+  open fun visitClassBody(node: PklClassBody): R? {
+    return visitElement(node)
   }
 
-  open fun visitClassMember(o: PklClassMember): R? {
-    return visitModuleMember(o)
+  open fun visitClassMember(node: PklClassMember): R? {
+    return visitModuleMember(node)
   }
 
-  open fun visitClassMethod(o: PklClassMethod): R? {
-    return visitClassMember(o)
+  open fun visitClassMethod(node: PklClassMethod): R? {
+    return visitClassMember(node)
   }
 
-  open fun visitClassProperty(o: PklClassProperty): R? {
-    return visitClassMember(o)
+  open fun visitClassProperty(node: PklClassProperty): R? {
+    return visitClassMember(node)
   }
 
-  open fun visitComparisonExpr(o: PklComparisonExpr): R? {
-    return visitExpr(o)
+  open fun visitComparisonExpr(node: PklComparisonExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitConstrainedType(o: PklConstrainedType): R? {
-    return visitType(o)
+  open fun visitConstrainedType(node: PklConstrainedType): R? {
+    return visitType(node)
   }
 
-  open fun visitDeclaredType(o: PklDeclaredType): R? {
-    return visitType(o)
+  open fun visitDeclaredType(node: PklDeclaredType): R? {
+    return visitType(node)
   }
 
-  open fun visitDefaultUnionType(o: PklDefaultUnionType): R? {
-    return visitType(o)
+  open fun visitDefaultUnionType(node: PklDefaultUnionType): R? {
+    return visitType(node)
   }
 
-  open fun visitElement(o: PklNode): R? {
+  open fun visitElement(node: PklNode): R? {
     return null
   }
 
-  open fun visitEqualityExpr(o: PklEqualityExpr): R? {
-    return visitExpr(o)
+  open fun visitEqualityExpr(node: PklEqualityExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitError(o: PklError): R? {
-    return visitElement(o)
+  open fun visitError(node: PklError): R? {
+    return visitElement(node)
   }
 
-  open fun visitExponentiationExpr(o: PklExponentiationExpr): R? {
-    return visitExpr(o)
+  open fun visitExponentiationExpr(node: PklExponentiationExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitExpr(o: PklExpr): R? {
-    return visitElement(o)
+  open fun visitExpr(node: PklExpr): R? {
+    return visitElement(node)
   }
 
-  open fun visitFalseLiteralExpr(o: PklFalseLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitFalseLiteralExpr(node: PklFalseLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitFloatLiteralExpr(o: PklFloatLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitFloatLiteralExpr(node: PklFloatLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitForGenerator(o: PklForGenerator): R? {
-    return visitObjectMember(o)
+  open fun visitForGenerator(node: PklForGenerator): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitFunctionLiteral(o: PklFunctionLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitFunctionLiteral(node: PklFunctionLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitFunctionType(o: PklFunctionType): R? {
-    return visitType(o)
+  open fun visitFunctionType(node: PklFunctionType): R? {
+    return visitType(node)
   }
 
-  open fun visitIdentifierOwner(o: IdentifierOwner): R? {
-    return visitElement(o)
+  open fun visitIdentifierOwner(node: IdentifierOwner): R? {
+    return visitElement(node)
   }
 
-  open fun visitIfExpr(o: PklIfExpr): R? {
-    return visitExpr(o)
+  open fun visitIfExpr(node: PklIfExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitImport(o: PklImport): R? {
-    return visitElement(o)
+  open fun visitImport(node: PklImport): R? {
+    return visitElement(node)
   }
 
-  open fun visitImportExpr(o: PklImportExpr): R? {
-    return visitExpr(o)
+  open fun visitImportExpr(node: PklImportExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitIntLiteralExpr(o: PklIntLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitIntLiteralExpr(node: PklIntLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitLetExpr(o: PklLetExpr): R? {
-    return visitExpr(o)
+  open fun visitLetExpr(node: PklLetExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitLogicalAndExpr(o: PklLogicalAndExpr): R? {
-    return visitExpr(o)
+  open fun visitLogicalAndExpr(node: PklLogicalAndExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitLogicalNotExpr(o: PklLogicalNotExpr): R? {
-    return visitExpr(o)
+  open fun visitLogicalNotExpr(node: PklLogicalNotExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitLogicalOrExpr(o: PklLogicalOrExpr): R? {
-    return visitExpr(o)
+  open fun visitLogicalOrExpr(node: PklLogicalOrExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitMemberPredicate(o: PklMemberPredicate): R? {
-    return visitObjectMember(o)
+  open fun visitMemberPredicate(node: PklMemberPredicate): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitMethodHeader(o: PklMethodHeader): R? {
-    return visitModifierListOwner(o)
+  open fun visitMethodHeader(node: PklMethodHeader): R? {
+    return visitModifierListOwner(node)
   }
 
-  open fun visitMlStringLiteral(o: PklMultiLineStringLiteral): R? {
-    return visitExpr(o)
+  open fun visitMlStringLiteral(node: PklMultiLineStringLiteral): R? {
+    return visitExpr(node)
   }
 
-  open fun visitModifierListOwner(o: PklModifierListOwner): R? {
-    return visitElement(o)
+  open fun visitModifierListOwner(node: PklModifierListOwner): R? {
+    return visitElement(node)
   }
 
-  open fun visitModule(o: PklModule): R? {
-    return visitElement(o)
+  open fun visitModule(node: PklModule): R? {
+    return visitElement(node)
   }
 
-  open fun visitModuleHeader(o: PklModuleHeader): R? {
-    return visitDocCommentOwner(o)
+  open fun visitModuleHeader(node: PklModuleHeader): R? {
+    return visitDocCommentOwner(node)
   }
 
-  open fun visitModuleExpr(o: PklModuleExpr): R? {
-    return visitExpr(o)
+  open fun visitModuleExpr(node: PklModuleExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitModuleExtendsAmendsClause(o: PklModuleExtendsAmendsClause): R? {
-    return visitElement(o)
+  open fun visitModuleExtendsAmendsClause(node: PklModuleExtendsAmendsClause): R? {
+    return visitElement(node)
   }
 
-  open fun visitModuleClause(o: PklModuleClause): R? {
-    return visitElement(o)
+  open fun visitModuleClause(node: PklModuleClause): R? {
+    return visitElement(node)
   }
 
-  open fun visitModuleMember(o: PklModuleMember): R? {
-    return visitElement(o)
+  open fun visitModuleMember(node: PklModuleMember): R? {
+    return visitElement(node)
   }
 
-  open fun visitModuleType(o: PklModuleType): R? {
-    return visitType(o)
+  open fun visitModuleType(node: PklModuleType): R? {
+    return visitType(node)
   }
 
-  open fun visitModuleUri(o: PklModuleUri): R? {
-    return visitElement(o)
+  open fun visitModuleUri(node: PklModuleUri): R? {
+    return visitElement(node)
   }
 
-  open fun visitMultiplicativeExpr(o: PklMultiplicativeExpr): R? {
-    return visitExpr(o)
+  open fun visitMultiplicativeExpr(node: PklMultiplicativeExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitNewExpr(o: PklNewExpr): R? {
-    return visitExpr(o)
+  open fun visitNewExpr(node: PklNewExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitNonNullExpr(o: PklNonNullExpr): R? {
-    return visitExpr(o)
+  open fun visitNonNullExpr(node: PklNonNullExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitNothingType(o: PklNothingType): R? {
-    return visitType(o)
+  open fun visitNothingType(node: PklNothingType): R? {
+    return visitType(node)
   }
 
-  open fun visitNullCoalesceExpr(o: PklNullCoalesceExpr): R? {
-    return visitExpr(o)
+  open fun visitNullCoalesceExpr(node: PklNullCoalesceExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitNullLiteralExpr(o: PklNullLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitNullLiteralExpr(node: PklNullLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitNullableType(o: PklNullableType): R? {
-    return visitType(o)
+  open fun visitNullableType(node: PklNullableType): R? {
+    return visitType(node)
   }
 
-  open fun visitObjectBody(o: PklObjectBody): R? {
-    return visitElement(o)
+  open fun visitObjectBody(node: PklObjectBody): R? {
+    return visitElement(node)
   }
 
-  open fun visitObjectBodyOwner(o: PklObjectBodyOwner): R? {
-    return visitElement(o)
+  open fun visitObjectBodyOwner(node: PklObjectBodyOwner): R? {
+    return visitElement(node)
   }
 
-  open fun visitObjectElement(o: PklObjectElement): R? {
-    return visitObjectMember(o)
+  open fun visitObjectElement(node: PklObjectElement): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitObjectEntry(o: PklObjectEntry): R? {
-    return visitObjectMember(o)
+  open fun visitObjectEntry(node: PklObjectEntry): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitObjectMember(o: PklObjectMember): R? {
-    return visitElement(o)
+  open fun visitObjectMember(node: PklObjectMember): R? {
+    return visitElement(node)
   }
 
-  open fun visitObjectMethod(o: PklObjectMethod): R? {
-    return visitObjectMember(o)
+  open fun visitObjectMethod(node: PklObjectMethod): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitObjectProperty(o: PklObjectProperty): R? {
-    return visitObjectMember(o)
+  open fun visitObjectProperty(node: PklObjectProperty): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitObjectSpread(o: PklObjectSpread): R? {
-    return visitObjectMember(o)
+  open fun visitObjectSpread(node: PklObjectSpread): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitOuterExpr(o: PklOuterExpr): R? {
-    return visitExpr(o)
+  open fun visitOuterExpr(node: PklOuterExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitParenthesizedExpr(o: PklParenthesizedExpr): R? {
-    return visitExpr(o)
+  open fun visitParenthesizedExpr(node: PklParenthesizedExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitParenthesizedType(o: PklParenthesizedType): R? {
-    return visitType(o)
+  open fun visitParenthesizedType(node: PklParenthesizedType): R? {
+    return visitType(node)
   }
 
-  open fun visitParameterList(o: PklParameterList): R? {
-    return visitElement(o)
+  open fun visitParameterList(node: PklParameterList): R? {
+    return visitElement(node)
   }
 
-  open fun visitPipeExpr(o: PklPipeExpr): R? {
-    return visitExpr(o)
+  open fun visitPipeExpr(node: PklPipeExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitQualifiedAccessExpr(o: PklQualifiedAccessExpr): R? {
-    return visitAccessExpr(o)
+  open fun visitQualifiedAccessExpr(node: PklQualifiedAccessExpr): R? {
+    return visitAccessExpr(node)
   }
 
-  open fun visitQualifiedIdentifier(o: PklQualifiedIdentifier): R? {
-    return visitElement(o)
+  open fun visitQualifiedIdentifier(node: PklQualifiedIdentifier): R? {
+    return visitElement(node)
   }
 
-  open fun visitReadExpr(o: PklReadExpr): R? {
-    return visitExpr(o)
+  open fun visitReadExpr(node: PklReadExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitSimpleTypeName(o: PklSimpleTypeName): R? {
-    return visitIdentifierOwner(o)
+  open fun visitSimpleTypeName(node: PklSimpleTypeName): R? {
+    return visitIdentifierOwner(node)
   }
 
-  open fun visitModuleName(o: PklModuleName): R? {
-    return visitIdentifierOwner(o)
+  open fun visitModuleName(node: PklModuleName): R? {
+    return visitIdentifierOwner(node)
   }
 
-  open fun visitStringConstant(o: PklStringConstant): R? {
-    return visitElement(o)
+  open fun visitStringConstant(node: PklStringConstant): R? {
+    return visitElement(node)
   }
 
-  open fun visitStringLiteral(o: PklSingleLineStringLiteral): R? {
-    return visitExpr(o)
+  open fun visitStringLiteral(node: PklSingleLineStringLiteral): R? {
+    return visitExpr(node)
   }
 
-  open fun visitStringLiteralType(o: PklStringLiteralType): R? {
-    return visitType(o)
+  open fun visitStringLiteralType(node: PklStringLiteralType): R? {
+    return visitType(node)
   }
 
-  open fun visitSubscriptExpr(o: PklSubscriptExpr): R? {
-    return visitExpr(o)
+  open fun visitSubscriptExpr(node: PklSubscriptExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitSuperAccessExpr(o: PklSuperAccessExpr): R? {
-    return visitAccessExpr(o)
+  open fun visitSuperAccessExpr(node: PklSuperAccessExpr): R? {
+    return visitAccessExpr(node)
   }
 
-  open fun visitSuperSubscriptExpr(o: PklSuperSubscriptExpr): R? {
-    return visitExpr(o)
+  open fun visitSuperSubscriptExpr(node: PklSuperSubscriptExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitTerminal(o: Terminal): R? {
-    return visitElement(o)
+  open fun visitTerminal(node: Terminal): R? {
+    return visitElement(node)
   }
 
-  open fun visitThisExpr(o: PklThisExpr): R? {
-    return visitExpr(o)
+  open fun visitThisExpr(node: PklThisExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitThrowExpr(o: PklThrowExpr): R? {
-    return visitExpr(o)
+  open fun visitThrowExpr(node: PklThrowExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitTraceExpr(o: PklTraceExpr): R? {
-    return visitExpr(o)
+  open fun visitTraceExpr(node: PklTraceExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitTrueLiteralExpr(o: PklTrueLiteralExpr): R? {
-    return visitExpr(o)
+  open fun visitTrueLiteralExpr(node: PklTrueLiteralExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitType(o: PklType): R? {
-    return visitElement(o)
+  open fun visitType(node: PklType): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeAlias(o: PklTypeAlias): R? {
-    return visitModuleMember(o)
+  open fun visitTypeAlias(node: PklTypeAlias): R? {
+    return visitModuleMember(node)
   }
 
-  open fun visitTypeAnnotation(o: PklTypeAnnotation): R? {
-    return visitElement(o)
+  open fun visitTypeAnnotation(node: PklTypeAnnotation): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeArgumentList(o: PklTypeArgumentList): R? {
-    return visitElement(o)
+  open fun visitTypeArgumentList(node: PklTypeArgumentList): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeName(o: PklTypeName): R? {
-    return visitElement(o)
+  open fun visitTypeName(node: PklTypeName): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeParameter(o: PklTypeParameter): R? {
-    return visitElement(o)
+  open fun visitTypeParameter(node: PklTypeParameter): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeParameterList(o: PklTypeParameterList): R? {
-    return visitElement(o)
+  open fun visitTypeParameterList(node: PklTypeParameterList): R? {
+    return visitElement(node)
   }
 
-  open fun visitTypeTestExpr(o: PklTypeTestExpr): R? {
-    return visitExpr(o)
+  open fun visitTypeTestExpr(node: PklTypeTestExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitTypeCastExpr(o: PklTypeCastExpr): R? {
-    return visitExpr(o)
+  open fun visitTypeCastExpr(node: PklTypeCastExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitTypedIdentifier(o: PklTypedIdentifier): R? {
-    return visitIdentifierOwner(o)
+  open fun visitTypedIdentifier(node: PklTypedIdentifier): R? {
+    return visitIdentifierOwner(node)
   }
 
-  open fun visitUnaryMinusExpr(o: PklUnaryMinusExpr): R? {
-    return visitExpr(o)
+  open fun visitUnaryMinusExpr(node: PklUnaryMinusExpr): R? {
+    return visitExpr(node)
   }
 
-  open fun visitUnionType(o: PklUnionType): R? {
-    return visitType(o)
+  open fun visitUnionType(node: PklUnionType): R? {
+    return visitType(node)
   }
 
-  open fun visitUnknownType(o: PklUnknownType): R? {
-    return visitType(o)
+  open fun visitUnknownType(node: PklUnknownType): R? {
+    return visitType(node)
   }
 
-  open fun visitUnqualifiedAccessExpr(o: PklUnqualifiedAccessExpr): R? {
-    return visitAccessExpr(o)
+  open fun visitUnqualifiedAccessExpr(node: PklUnqualifiedAccessExpr): R? {
+    return visitAccessExpr(node)
   }
 
-  open fun visitWhenGenerator(o: PklWhenGenerator): R? {
-    return visitObjectMember(o)
+  open fun visitWhenGenerator(node: PklWhenGenerator): R? {
+    return visitObjectMember(node)
   }
 
-  open fun visitDocCommentOwner(o: PklDocCommentOwner): R? {
-    return visitElement(o)
+  open fun visitDocCommentOwner(node: PklDocCommentOwner): R? {
+    return visitElement(node)
   }
 
-  open fun visitLineComment(o: PklLineComment): R? {
+  open fun visitLineComment(node: PklLineComment): R? {
     return null
   }
 
-  open fun visitBlockComment(o: PklBlockComment): R? {
+  open fun visitBlockComment(node: PklBlockComment): R? {
     return null
   }
 
-  open fun visitShebangComment(o: PklShebangComment): R? {
+  open fun visitShebangComment(node: PklShebangComment): R? {
     return null
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/AccessExprAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/AccessExprAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,12 +177,12 @@ class AccessExprAnalyzer(project: Project) : Analyzer(project) {
           }
         }
 
-        override fun visitModuleExpr(o: PklModuleExpr) {
-          checkConstAccess(o, diagnosticsHolder)
+        override fun visitModuleExpr(node: PklModuleExpr) {
+          checkConstAccess(node, diagnosticsHolder)
         }
 
-        override fun visitThisExpr(o: PklThisExpr) {
-          checkConstAccess(o, diagnosticsHolder)
+        override fun visitThisExpr(node: PklThisExpr) {
+          checkConstAccess(node, diagnosticsHolder)
         }
       }
     )

--- a/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt
@@ -62,13 +62,13 @@ private fun PklExpr?.doInferExprTypeFromContext(
   val result =
     parent.accept(
       object : PklVisitor<Type>() {
-        override fun visitExpr(parent: PklExpr): Type = Type.Unknown
+        override fun visitExpr(node: PklExpr): Type = Type.Unknown
 
-        override fun visitObjectEntry(parent: PklObjectEntry): Type {
+        override fun visitObjectEntry(node: PklObjectEntry): Type {
           return when (expr) {
-            parent.keyExpr -> {
+            node.keyExpr -> {
               val enclosingObjectType =
-                parent.computeThisType(base, bindings, context).toClassType(base, context)
+                node.computeThisType(base, bindings, context).toClassType(base, context)
                   ?: return Type.Unknown
               when {
                 enclosingObjectType.classEquals(base.listingType) -> base.intType
@@ -77,12 +77,12 @@ private fun PklExpr?.doInferExprTypeFromContext(
                 else -> Type.Unknown
               }
             }
-            parent.valueExpr -> {
+            node.valueExpr -> {
               val defaultExpectedType by lazy {
-                parent.computeResolvedImportType(base, bindings, context, canInferExprBody = false)
+                node.computeResolvedImportType(base, bindings, context, canInferExprBody = false)
               }
               val resolvedKeyClass by lazy {
-                val keyExpr = (parent.keyExpr as? PklUnqualifiedAccessExpr) ?: return@lazy null
+                val keyExpr = (node.keyExpr as? PklUnqualifiedAccessExpr) ?: return@lazy null
                 val visitor = ResolveVisitors.firstElementNamed(keyExpr.memberNameText, base, true)
                 keyExpr.resolve(base, null, bindings, visitor, context) as? PklClass
               }
@@ -90,7 +90,7 @@ private fun PklExpr?.doInferExprTypeFromContext(
               if (
                 // optimization: only compute type if within a property called "converters" or
                 // "convertPropertyTransformers" in a BaseValueRenderer subclass
-                parent.keyExpr
+                node.keyExpr
                   ?.computeThisType(base, bindings, context)
                   ?.isSubtypeOf(base.baseValueRenderer, base, context) == true
               ) {
@@ -113,45 +113,45 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitObjectSpread(parent: PklObjectSpread): Type {
+        override fun visitObjectSpread(node: PklObjectSpread): Type {
           val underlyingType =
             when (expr) {
-              parent.expr -> {
+              node.expr -> {
                 val enclosingObjectType =
-                  parent.computeThisType(base, bindings, context).toClassType(base, context)
+                  node.computeThisType(base, bindings, context).toClassType(base, context)
                 if (enclosingObjectType == null) base.iterableType
                 else base.spreadType(enclosingObjectType)
               }
               else -> base.iterableType
             }
-          return if (parent.isNullable) underlyingType.nullable(base, context) else underlyingType
+          return if (node.isNullable) underlyingType.nullable(base, context) else underlyingType
         }
 
-        override fun visitMemberPredicate(parent: PklMemberPredicate): Type =
+        override fun visitMemberPredicate(node: PklMemberPredicate): Type =
           when (expr) {
-            parent.conditionExpr -> base.booleanType
-            parent.valueExpr ->
-              parent.computeResolvedImportType(base, bindings, context, canInferExprBody = false)
+            node.conditionExpr -> base.booleanType
+            node.valueExpr ->
+              node.computeResolvedImportType(base, bindings, context, canInferExprBody = false)
             else -> Type.Unknown // parse error
           }
 
-        override fun visitWhenGenerator(parent: PklWhenGenerator): Type =
+        override fun visitWhenGenerator(node: PklWhenGenerator): Type =
           when (expr) {
-            parent.conditionExpr -> base.booleanType
+            node.conditionExpr -> base.booleanType
             else -> Type.Unknown // parse error
           }
 
-        override fun visitForGenerator(parent: PklForGenerator): Type =
+        override fun visitForGenerator(node: PklForGenerator): Type =
           when (expr) {
-            parent.iterableExpr -> base.iterableType
+            node.iterableExpr -> base.iterableType
             else -> Type.Unknown // parse error
           }
 
-        override fun visitArgumentList(parent: PklArgumentList): Type {
-          val argIndex = parent.elements.indexOfFirst { it === expr }
+        override fun visitArgumentList(node: PklArgumentList): Type {
+          val argIndex = node.elements.indexOfFirst { it === expr }
           if (argIndex == -1) return Type.Unknown
 
-          val accessExpr = parent.parent as PklAccessExpr
+          val accessExpr = node.parent as PklAccessExpr
           val visitor =
             ResolveVisitors.paramTypesOfFirstMethodNamed(
               accessExpr.memberNameText,
@@ -173,11 +173,11 @@ private fun PklExpr?.doInferExprTypeFromContext(
           return paramTypes.getOrNull(argIndex) ?: Type.Unknown
         }
 
-        override fun visitSubscriptExpr(parent: PklSubscriptExpr): Type {
+        override fun visitSubscriptExpr(node: PklSubscriptExpr): Type {
           return when (expr) {
-            parent.leftExpr -> base.subscriptableType
+            node.leftExpr -> base.subscriptableType
             else -> {
-              doVisitSubscriptExpr(parent.leftExpr.computeExprType(base, bindings, context))
+              doVisitSubscriptExpr(node.leftExpr.computeExprType(base, bindings, context))
             }
           }
         }
@@ -209,17 +209,17 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitExponentiationExpr(parent: PklExponentiationExpr): Type {
+        override fun visitExponentiationExpr(node: PklExponentiationExpr): Type {
           return when (expr) {
-            parent.leftExpr ->
+            node.leftExpr ->
               Type.union(base.numberType, base.dataSizeType, base.durationType, base, context)
             else -> base.numberType
           }
         }
 
-        override fun visitMultiplicativeExpr(parent: PklMultiplicativeExpr): Type {
+        override fun visitMultiplicativeExpr(node: PklMultiplicativeExpr): Type {
           return doVisitMultiplicativeBinExpr(
-            parent.otherExpr(expr).computeExprType(base, bindings, context)
+            node.otherExpr(expr).computeExprType(base, bindings, context)
           )
         }
 
@@ -239,9 +239,9 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitAdditiveExpr(parent: PklAdditiveExpr): Type {
+        override fun visitAdditiveExpr(node: PklAdditiveExpr): Type {
           return doVisitAdditiveBinExpr(
-            parent.otherExpr(expr).computeExprType(base, bindings, context)
+            node.otherExpr(expr).computeExprType(base, bindings, context)
           )
         }
 
@@ -280,9 +280,9 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitComparisonExpr(parent: PklComparisonExpr): Type {
+        override fun visitComparisonExpr(node: PklComparisonExpr): Type {
           return doVisitComparisonBinExpr(
-            parent.otherExpr(expr).computeExprType(base, bindings, context)
+            node.otherExpr(expr).computeExprType(base, bindings, context)
           )
         }
 
@@ -305,17 +305,16 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitLogicalAndExpr(parent: PklLogicalAndExpr): Type = base.booleanType
+        override fun visitLogicalAndExpr(node: PklLogicalAndExpr): Type = base.booleanType
 
-        override fun visitPipeExpr(parent: PklPipeExpr): Type =
+        override fun visitPipeExpr(node: PklPipeExpr): Type =
           when (expr) {
-            parent.rightExpr -> {
-              val paramType = parent.leftExpr.computeExprType(base, mapOf(), context)
-              val returnType = inferParentExpr(parent)
+            node.rightExpr -> {
+              val paramType = node.leftExpr.computeExprType(base, mapOf(), context)
+              val returnType = inferParentExpr(node)
               Type.function1(paramType, returnType, base)
             }
-            parent.leftExpr ->
-              doVisitPipeExpr(parent.rightExpr.computeExprType(base, mapOf(), context))
+            node.leftExpr -> doVisitPipeExpr(node.rightExpr.computeExprType(base, mapOf(), context))
             else -> Type.Unknown // parse error
           }
 
@@ -337,40 +336,40 @@ private fun PklExpr?.doInferExprTypeFromContext(
           }
         }
 
-        override fun visitIfExpr(parent: PklIfExpr): Type =
+        override fun visitIfExpr(node: PklIfExpr): Type =
           when (expr) {
-            parent.conditionExpr -> base.booleanType
-            parent.thenExpr,
-            parent.elseExpr -> inferParentExpr(parent)
+            node.conditionExpr -> base.booleanType
+            node.thenExpr,
+            node.elseExpr -> inferParentExpr(node)
             else -> Type.Unknown
           }
 
-        override fun visitLetExpr(parent: PklLetExpr): Type =
+        override fun visitLetExpr(node: PklLetExpr): Type =
           when (expr) {
-            parent.varExpr -> parent.parameter?.type.toType(base, bindings, context)
-            parent.bodyExpr -> inferParentExpr(parent)
+            node.varExpr -> node.parameter.type.toType(base, bindings, context)
+            node.bodyExpr -> inferParentExpr(node)
             else -> Type.Unknown
           }
 
-        override fun visitParenthesizedExpr(parent: PklParenthesizedExpr): Type {
+        override fun visitParenthesizedExpr(node: PklParenthesizedExpr): Type {
           return doInferExprTypeFromContext(
             base,
             bindings,
-            parent.parent,
+            node.parent,
             context,
             resolveTypeParamsInParamTypes,
             canInferParentExpr,
           )
         }
 
-        override fun visitReadExpr(parent: PklReadExpr): Type = base.stringType
+        override fun visitReadExpr(node: PklReadExpr): Type = base.stringType
 
-        override fun visitThrowExpr(parent: PklThrowExpr): Type = base.stringType
+        override fun visitThrowExpr(node: PklThrowExpr): Type = base.stringType
 
-        override fun visitUnaryMinusExpr(parent: PklUnaryMinusExpr): Type =
+        override fun visitUnaryMinusExpr(node: PklUnaryMinusExpr): Type =
           base.multiplicativeOperandType
 
-        override fun visitLogicalNotExpr(parent: PklLogicalNotExpr): Type = base.booleanType
+        override fun visitLogicalNotExpr(node: PklLogicalNotExpr): Type = base.booleanType
 
         private fun inferParentExpr(parent: PklExpr) =
           when {


### PR DESCRIPTION
This fixes warnings like:

```
w: file:///Users/danielchao/code/apple/pkl-lsp/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt:366:36 The corresponding parameter in the supertype 'PklVisitor' is named 'node'. This may cause problems when calling this function with named arguments.
w: file:///Users/danielchao/code/apple/pkl-lsp/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt:368:37 The corresponding parameter in the supertype 'PklVisitor' is named 'node'. This may cause problems when calling this function with named arguments.
w: file:///Users/danielchao/code/apple/pkl-lsp/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt:370:42 The corresponding parameter in the supertype 'PklVisitor' is named 'node'. This may cause problems when calling this function with named arguments.
w: file:///Users/danielchao/code/apple/pkl-lsp/src/main/kotlin/org/pkl/lsp/type/InferExprTypeFromContext.kt:373:42 The corresponding parameter in the supertype 'PklVisitor' is named 'node'. This may cause problems when calling this function with named arguments.
```