### PR TITLE
Upgrade to zig 0.16.0, switch to download from mirror

### DIFF
--- a/buildSrc/src/main/kotlin/zig.gradle.kts
+++ b/buildSrc/src/main/kotlin/zig.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,8 @@ import kotlin.io.path.exists
 
 plugins { id("de.undercouch.download") }
 
+val mirror = "https://zigmirror.com" // from https://ziglang.org/download/community-mirrors.txt
+
 val buildInfo = extensions.create<BuildInfo>("buildInfo", project)
 
 private val downloadFile
@@ -34,7 +36,7 @@ val downloadZig by
     doLast { println("Downloaded Zig to $downloadFile") }
 
     src(
-      "https://ziglang.org/download/${buildInfo.zig.version}/zig-${buildInfo.os.canonicalName}-${buildInfo.arch.cName}-${buildInfo.zig.version}.$extension"
+      "$mirror/zig-${buildInfo.arch.cName}-${buildInfo.os.canonicalName}-${buildInfo.zig.version}.$extension"
     )
     dest(downloadFile)
     overwrite(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,15 +17,14 @@ spotless = "6.25.0"
 treeSitterRepo = "v0.25.3" # git tag name
 treeSitterPklRepo = "f9405e40597d7dac637a6b49e7d26c4515cb2a34" # TODO: switch to tag once released
 #treeSitterPklRepo = "v0.21.0" # git tag name
-zig = "0.13.0" # used for cross-compiling tree-sitter libs
 
 # Only need checksums for distributions that we might run builds on.
-# Computed with `curl -s <DOWNLOAD_URL> | shasum -a 256`.
-# Download links found here: https://ziglang.org/download/
-zigSha256-macos-aarch64 = "46fae219656545dfaf4dce12fb4e8685cec5b51d721beee9389ab4194d43394c"
-zigSha256-linux-amd64 = "d45312e61ebcc48032b77bc4cf7fd6915c11fa16e4aad116b66c9468211230ea"
-zigSha256-windows-amd64 = "d859994725ef9402381e557c60bb57497215682e355204d754ee3df75ee3c158"
-zigSha256-linux-aarch64 = "041ac42323837eb5624068acd8b00cd5777dac4cf91179e8dad7a7e90dd0c556"
+# Use `../scripts/update_zig.sh <version>` to update these
+zig = "0.16.0" # used for cross-compiling tree-sitter libs
+zigSha256-macos-aarch64 = "b23d70deaa879b5c2d486ed3316f7eaa53e84acf6fc9cc747de152450d401489"
+zigSha256-linux-amd64 = "70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00"
+zigSha256-windows-amd64 = "68659eb5f1e4eb1437a722f1dd889c5a322c9954607f5edcf337bc3684a75a7e"
+zigSha256-linux-aarch64 = "ea4b09bfb22ec6f6c6ceac57ab63efb6b46e17ab08d21f69f3a48b38e1534f17"
 
 [libraries]
 assertJ = { group = "org.assertj", name = "assertj-core", version.ref = "assertj" }

--- a/scripts/update_zig.sh
+++ b/scripts/update_zig.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+set -eo pipefail
+
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+  echo "Usage: update_zig.sh <version>"
+  exit 1
+fi
+
+if ! which minisign > /dev/null 2> /dev/null; then
+  echo "minisign is required to verify zig updates"
+  echo "Install via homebrew or https://jedisct1.github.io/minisign/"
+  exit 1
+fi
+
+SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+GRADLE_VERSIONS="$SCRIPT_DIR/../gradle/libs.versions.toml"
+DIR="$(mktemp -d -t pkl-lsp-zig)"
+echo "+ cd $DIR"
+cd "$DIR"
+
+VARIANTS=(
+  "macos-aarch64"
+  "linux-amd64"
+  "windows-amd64"
+  "linux-aarch64"
+)
+
+FILENAMES=(
+  "zig-aarch64-macos-$VERSION.tar.xz"
+  "zig-x86_64-linux-$VERSION.tar.xz"
+  "zig-x86_64-windows-$VERSION.zip"
+  "zig-aarch64-linux-$VERSION.tar.xz"
+)
+
+# from https://ziglang.org/download/
+PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
+
+MIRROR="https://zigmirror.com" # this one is fast!
+#MIRROR="$(curl -sSL https://ziglang.org/download/community-mirrors.txt | sort -R | head -n 1)"
+
+DOWNLOAD_ARGS="--parallel"
+for i in "${!FILENAMES[@]}"; do
+  DOWNLOAD_ARGS="$DOWNLOAD_ARGS -LO $MIRROR/${FILENAMES[$i]}"
+  DOWNLOAD_ARGS="$DOWNLOAD_ARGS -LO $MIRROR/${FILENAMES[$i]}.minisig"
+done
+
+echo "+ curl $DOWNLOAD_ARGS"
+# shellcheck disable=SC2086
+curl $DOWNLOAD_ARGS
+
+for i in "${!FILENAMES[@]}"; do
+  echo "Verifying ${FILENAMES[$i]}"
+  minisign -Vm "${FILENAMES[$i]}" -P "$PUBKEY"
+done
+
+echo "Updating version catalog"
+perl -pi -e "s/zig = \"[^\"]+\"/zig = \"$VERSION\"/" "$GRADLE_VERSIONS"
+for i in "${!FILENAMES[@]}"; do
+  echo "[$i/${#FILENAMES[@]}]   Hashing ${FILENAMES[$i]}"
+  HASH="$(sha256sum "${FILENAMES[$i]}" | awk '{print $1}')"
+  perl -pi -e "s/zigSha256-${VARIANTS[$i]} = \"[a-z0-9]+\"/zigSha256-${VARIANTS[$i]} = \"$HASH\"/" "$GRADLE_VERSIONS"
+done
+
+echo "Cleaning up"
+#rm -rf "$DIR"
+
+echo "Done!"


### PR DESCRIPTION
The zig project doesn't guarantee uptime or performance for their official package downloads, so this PR switches to use one of the recommended community mirrors.

This adds a script that does the hard work of downloading, verifying, and hashing zig for the 4 build platforms we support then updating libs.versions.toml with the new zig version and hashes.