### PR TITLE
Fix test flakiness

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/SettingsManager.kt
@@ -33,10 +33,10 @@ import org.pkl.lsp.util.ModificationTracker
 
 @Serializable
 data class WorkspaceSettings(
-  var pklCliPath: Path? = null,
-  var grammarVersion: GrammarVersion? = null,
-  var modulepath: List<Path> = emptyList(),
-  var excludedDirectories: List<String> = emptyList(),
+  val pklCliPath: Path? = null,
+  val grammarVersion: GrammarVersion? = null,
+  val modulepath: List<Path> = emptyList(),
+  val excludedDirectories: List<String> = emptyList(),
 )
 
 class SettingsManager(project: Project) : Component(project), ModificationTracker {
@@ -53,6 +53,11 @@ class SettingsManager(project: Project) : Component(project), ModificationTracke
     if (folders != null) {
       workspaceFolders.addAll(folders)
     }
+  }
+
+  fun update(updater: (WorkspaceSettings) -> WorkspaceSettings) {
+    settings = updater(settings)
+    updateCount.incrementAndGet()
   }
 
   override fun initialize(): CompletableFuture<*> = loadSettings().also { initialized = it }
@@ -169,17 +174,17 @@ class SettingsManager(project: Project) : Component(project), ModificationTracke
             append("excludedDirectories = $excludedDirectories")
           }
         )
-        settings.pklCliPath = resolvePklCliPath(cliPath as JsonElement)
-        settings.grammarVersion = resolveGrammarVersion(grammarVersion as JsonElement)
-        settings.modulepath = resolveModulepath(modulepath as JsonElement)
-        settings.excludedDirectories =
-          resolveExcludedDirectories(excludedDirectories as JsonElement)
+        update { settings ->
+          settings.copy(
+            pklCliPath = resolvePklCliPath(cliPath as JsonElement),
+            grammarVersion = resolveGrammarVersion(grammarVersion as JsonElement),
+            modulepath = resolveModulepath(modulepath as JsonElement),
+            excludedDirectories = resolveExcludedDirectories(excludedDirectories as JsonElement),
+          )
+        }
       }
       .exceptionally { logger.error("Failed to fetch settings: ${it.cause}") }
-      .whenComplete { _, _ ->
-        logger.log("Settings changed to $settings")
-        updateCount.incrementAndGet()
-      }
+      .whenComplete { _, _ -> logger.log("Settings changed to $settings") }
   }
 
   private fun findPklCliOnPath(): Path? {

--- a/src/test/kotlin/org/pkl/lsp/CompletionFeatureTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/CompletionFeatureTest.kt
@@ -48,7 +48,9 @@ class CompletionFeatureTest : LspTestBase() {
 
   @Test
   fun `complete modulepath import`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
+    fakeProject.settingsManager.update {
+      it.copy(modulepath = listOf(testProjectDir.resolve("lib")))
+    }
     createPklFile("lib/target.pkl", "")
     createPklFile("import \"modulepath:/<caret>\"")
     val completions = getCompletions()
@@ -57,8 +59,9 @@ class CompletionFeatureTest : LspTestBase() {
 
   @Test
   fun `modulepath import completion prioritizes earlier entries`() {
-    fakeProject.settingsManager.settings.modulepath =
-      listOf(testProjectDir.resolve("lib"), testProjectDir.resolve("lib2"))
+    fakeProject.settingsManager.update {
+      it.copy(modulepath = listOf(testProjectDir.resolve("lib"), testProjectDir.resolve("lib2")))
+    }
     createPklFile("lib/target.pkl", "")
     createPklFile("lib2/target.pkl", "")
     createPklFile("import \"modulepath:/<caret>\"")
@@ -69,18 +72,20 @@ class CompletionFeatureTest : LspTestBase() {
   }
 
   @Test
-  fun `complete modulepath archive import`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib.jar"))
-    createArchive("lib.jar", mapOf("file.pkl" to "", "dir/file2.pkl" to ""))
+  fun `complete modulepath archive import`(@TempDir tempDir: Path) {
+    val libJar = tempDir.resolve("lib.jar")
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(libJar)) }
+    createArchive(libJar, mapOf("file.pkl" to "", "dir/file2.pkl" to ""))
     createPklFile("import \"modulepath:/<caret>\"")
     val completions = getCompletions()
     assertThat(completions.map { it.label }).isEqualTo(listOf("dir", "file.pkl"))
   }
 
   @Test
-  fun `complete modulepath archive import in directory`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib.jar"))
-    createArchive("lib.jar", mapOf("dir/target.pkl" to ""))
+  fun `complete modulepath archive import in directory`(@TempDir tempDir: Path) {
+    val libJar = tempDir.resolve("lib.jar")
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(libJar)) }
+    createArchive(libJar, mapOf("dir/target.pkl" to ""))
     createPklFile("import \"modulepath:/dir/<caret>\"")
     val completions = getCompletions()
     assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
@@ -88,11 +93,11 @@ class CompletionFeatureTest : LspTestBase() {
 
   @Test
   fun `complete absolute paths within modulepath`(@TempDir tempDir: Path) {
-    fakeProject.settingsManager.settings.modulepath = listOf(tempDir)
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir)) }
     createPklFile(tempDir.resolve("bar.pkl").toString(), "bar = 1")
     createPklFile(tempDir.resolve("foo.pkl").toString(), "import \"/<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).isEqualTo(listOf("bar.pkl", "foo.pkl"))
+    assertThat(completions.map { it.label }).hasSameElementsAs(listOf("bar.pkl", "foo.pkl"))
   }
 
   @Test
@@ -100,7 +105,7 @@ class CompletionFeatureTest : LspTestBase() {
     @TempDir tempDir1: Path,
     @TempDir tempDir2: Path,
   ) {
-    fakeProject.settingsManager.settings.modulepath = listOf(tempDir1, tempDir2)
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir1, tempDir2)) }
     createPklFile(tempDir1.resolve("bar/baz.pkl").toString(), "bar = 1")
     createPklFile(tempDir2.resolve("bar/foo.pkl").toString(), "import \"./<caret>\"")
     val completions = getCompletions()

--- a/src/test/kotlin/org/pkl/lsp/DiagnosticsSnippetTestEngine.kt
+++ b/src/test/kotlin/org/pkl/lsp/DiagnosticsSnippetTestEngine.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ class DiagnosticsSnippetTestEngine : InputOutputTestEngine() {
     val project = server.project
     System.getProperty("pklExecutable")?.let { executablePath ->
       TestLanguageClient.settings["Pkl" to "pkl.cli.path"] = executablePath
-      project.settingsManager.settings.pklCliPath = Path.of(executablePath)
+      project.settingsManager.update { it.copy(pklCliPath = Path.of(executablePath)) }
     }
     project
   }

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionTest.kt
@@ -15,9 +15,11 @@
  */
 package org.pkl.lsp
 
-import java.nio.file.Paths
+import java.nio.file.Path
+import kotlin.io.path.absolutePathString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.pkl.lsp.ast.*
 
 class GoToDefinitionTest : LspTestBase() {
@@ -221,9 +223,10 @@ class GoToDefinitionTest : LspTestBase() {
   }
 
   @Test
-  fun `resolve modulepath import`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
-    createPklFile("lib/target.pkl", "")
+  fun `resolve modulepath import`(@TempDir tempDir: Path) {
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir)) }
+    val file = tempDir.resolve("target.pkl")
+    createPklFile(file, "")
     createPklFile(
       """
       import "modulepath:/target<caret>.pkl"
@@ -234,15 +237,19 @@ class GoToDefinitionTest : LspTestBase() {
     assertThat(resolved).hasSize(1)
     assertThat(resolved[0]).isInstanceOf(PklModule::class.java)
     val resolvedFile = resolved.first().containingFile
-    assertThat(resolvedFile.uri.path).endsWith("/lib/target.pkl")
+    assertThat(Path.of(resolvedFile.uri).absolutePathString()).isEqualTo(file.absolutePathString())
   }
 
   @Test
-  fun `modulepath import resolving prioritizes earlier entries`() {
-    fakeProject.settingsManager.settings.modulepath =
-      listOf(testProjectDir.resolve("lib"), testProjectDir.resolve("lib2"))
-    createPklFile("lib/target.pkl", "")
-    createPklFile("lib2/target.pkl", "")
+  fun `modulepath import resolving prioritizes earlier entries`(@TempDir tempDir: Path) {
+    val modulePath1 = tempDir.resolve("lib")
+    val modulePath2 = tempDir.resolve("lib2")
+    val module1 = modulePath1.resolve("target.pkl")
+    val module2 = modulePath2.resolve("target.pkl")
+
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(modulePath1, modulePath2)) }
+    createPklFile(module1, "")
+    createPklFile(module2, "")
     createPklFile(
       """
       import "modulepath:/target<caret>.pkl"
@@ -253,14 +260,17 @@ class GoToDefinitionTest : LspTestBase() {
     assertThat(resolved).hasSize(1)
     assertThat(resolved[0]).isInstanceOf(PklModule::class.java)
     val resolvedFile = resolved.first().containingFile
-    assertThat(resolvedFile.uri.path).endsWith("/lib/target.pkl")
+    assertThat(Path.of(resolvedFile.uri).absolutePathString())
+      .isEqualTo(module1.absolutePathString())
   }
 
   @Test
-  fun `resolve field in modulepath`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
+  fun `resolve field in modulepath`(@TempDir tempDir: Path) {
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir)) }
+    val targetModulePath = tempDir.resolve("Target.pkl")
+
     createPklFile(
-      "lib/Target.pkl",
+      targetModulePath,
       """
       module Target
 
@@ -283,14 +293,16 @@ class GoToDefinitionTest : LspTestBase() {
     assertThat(resolved[0]).isInstanceOf(PklClassProperty::class.java)
     assertThat((resolved[0] as PklClassProperty).name).isEqualTo("field")
     val resolvedFile = resolved.first().containingFile
-    assertThat(resolvedFile.uri.path).endsWith("/lib/Target.pkl")
+    assertThat(Path.of(resolvedFile.uri).absolutePathString())
+      .isEqualTo(targetModulePath.absolutePathString())
   }
 
   @Test
-  fun `resolve relative field in modulepath`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
+  fun `resolve relative field in modulepath`(@TempDir tempDir: Path) {
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir)) }
+    val targetModulePath = tempDir.resolve("Target.pkl")
     createPklFile(
-      "lib/Target.pkl",
+      targetModulePath,
       """
       module Target
 
@@ -299,11 +311,11 @@ class GoToDefinitionTest : LspTestBase() {
         .trimIndent(),
     )
     createPklFile(
-      "lib/Stopover.pkl",
+      tempDir.resolve("Stopover.pkl"),
       """
       module Stopover
 
-      import "./Target.pkl"
+      import "Target.pkl"
 
       target: Target
     """
@@ -326,15 +338,21 @@ class GoToDefinitionTest : LspTestBase() {
     assertThat(resolved[0]).isInstanceOf(PklClassProperty::class.java)
     assertThat((resolved[0] as PklClassProperty).name).isEqualTo("field")
     val resolvedFile = resolved.first().containingFile
-    assertThat(resolvedFile.uri.path).endsWith("/lib/Target.pkl")
+    assertThat(resolvedFile.uri.path).endsWith("Target.pkl")
   }
 
   @Test
-  fun `resolve modulepath field in modulepath`() {
-    fakeProject.settingsManager.settings.modulepath =
-      listOf(testProjectDir.resolve("nested"), testProjectDir.resolve("lib"))
+  fun `resolve modulepath field in modulepath`(@TempDir tempDir: Path) {
+
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir)) }
+    val modulepath1 = tempDir.resolve("nested")
+    val modulepath2 = tempDir.resolve("lib")
+
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(modulepath1, modulepath2)) }
+    val target = modulepath1.resolve("Target.pkl")
+
     createPklFile(
-      "nested/Target.pkl",
+      target,
       """
       module Target
 
@@ -343,7 +361,7 @@ class GoToDefinitionTest : LspTestBase() {
         .trimIndent(),
     )
     createPklFile(
-      "lib/Stopover.pkl",
+      modulepath2.resolve("Stopover.pkl"),
       """
       module Stopover
 
@@ -370,13 +388,14 @@ class GoToDefinitionTest : LspTestBase() {
     assertThat(resolved[0]).isInstanceOf(PklClassProperty::class.java)
     assertThat((resolved[0] as PklClassProperty).name).isEqualTo("field")
     val resolvedFile = resolved.first().containingFile
-    assertThat(resolvedFile.uri.path).endsWith("/nested/Target.pkl")
+    assertThat(Path.of(resolvedFile.uri).absolutePathString())
+      .isEqualTo(target.absolutePathString())
   }
 
   @Test
-  fun `resolve modulepath archive import`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib.jar"))
-    createArchive("lib.jar", mapOf("dir/target.pkl" to ""))
+  fun `resolve modulepath archive import inside archive`(@TempDir tempDir: Path) {
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(tempDir.resolve("lib.jar"))) }
+    createArchive(tempDir.resolve("lib.jar"), mapOf("dir/target.pkl" to ""))
     createPklFile(
       """
       import "modulepath:/dir/target<caret>.pkl"
@@ -391,19 +410,61 @@ class GoToDefinitionTest : LspTestBase() {
   }
 
   @Test
-  fun `relative resolution across modulepath elements prefers earlier directory`() {
-    fakeProject.settingsManager.settings.modulepath =
-      listOf(
-        testProjectDir.resolve("x/y"),
-        testProjectDir.resolve("x/z"),
-        testProjectDir.resolve("x/z.zip"),
+  fun `relative resolution across modulepath elements prefers earlier directory`(
+    @TempDir tempDir: Path
+  ) {
+    fakeProject.settingsManager.update {
+      it.copy(
+        modulepath =
+          listOf(tempDir.resolve("x/y"), tempDir.resolve("x/z"), tempDir.resolve("x/z.zip"))
       )
-    createArchive("x/z.zip", mapOf("Bar.pkl" to "baz = 1"))
-    createPklFile("x/z/Bar.pkl", "baz = 0")
+    }
+    createArchive(tempDir.resolve("x/z.zip"), mapOf("Bar.pkl" to "baz = 1"))
+    createPklFile(tempDir.resolve("x/z/Bar.pkl"), "baz = 0")
     createPklFile(
-      "x/y/Foo.pkl",
+      tempDir.resolve("x/y/Foo.pkl"),
       """
       import "Bar.pkl"
+
+      bar: Bar
+    """
+        .trimIndent(),
+    )
+    createPklFile(
+      tempDir.resolve("x/test.pkl"),
+      """
+      import "modulepath:/Foo.pkl"
+
+      foo = new Foo {
+        bar {
+          baz<caret> = 2
+        }
+      }
+    """
+        .trimIndent(),
+    )
+    val resolved = goToDefinition().single()
+    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
+    val uri = resolved.enclosingModule!!.uri
+    assertThat(uri.normalize().path.endsWith("/x/z/Bar.pkl"))
+  }
+
+  @Test
+  fun `relative resolution across modulepath elements prefers earlier archive`(
+    @TempDir tempDir: Path
+  ) {
+    fakeProject.settingsManager.update {
+      it.copy(
+        modulepath =
+          listOf(tempDir.resolve("x/y"), tempDir.resolve("x/z.zip"), tempDir.resolve("x/z"))
+      )
+    }
+    createArchive(tempDir.resolve("x/z.zip"), mapOf("Bar.pkl" to "baz = 1"))
+    createPklFile(tempDir.resolve("x/z/Bar.pkl"), "baz = 0")
+    createPklFile(
+      tempDir.resolve("x/y/Foo.pkl"),
+      """
+      import "./Bar.pkl"
 
       bar: Bar
     """
@@ -425,45 +486,6 @@ class GoToDefinitionTest : LspTestBase() {
     val resolved = goToDefinition().single()
     assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
     val uri = resolved.enclosingModule!!.uri
-    val path = Paths.get(uri).normalize().toString()
-    assertThat(path).endsWith("/x/z/Bar.pkl")
-  }
-
-  @Test
-  fun `relative resolution across modulepath elements prefers earlier archive`() {
-    fakeProject.settingsManager.settings.modulepath =
-      listOf(
-        testProjectDir.resolve("x/y"),
-        testProjectDir.resolve("x/z.zip"),
-        testProjectDir.resolve("x/z"),
-      )
-    createArchive("x/z.zip", mapOf("Bar.pkl" to "baz = 1"))
-    createPklFile("x/z/Bar.pkl", "baz = 0")
-    createPklFile(
-      "x/y/Foo.pkl",
-      """
-      import "./Bar.pkl"
-
-      bar: Bar
-    """
-        .trimIndent(),
-    )
-    createPklFile(
-      "x/test.pkl",
-      """
-      import("modulepath:/Foo.pkl")
-
-      foo = new Foo {
-        bar {
-          baz<caret> = 2
-        }
-      }
-    """
-        .trimIndent(),
-    )
-    val resolved = goToDefinition().single()
-    assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
-    val uri = resolved.enclosingModule!!.uri
     assertThat(uri.scheme).isEqualTo("jar")
     assertThat(uri.schemeSpecificPart).startsWith("file:")
     assertThat(uri.schemeSpecificPart).endsWith("/x/z.zip!/Bar.pkl")
@@ -471,7 +493,9 @@ class GoToDefinitionTest : LspTestBase() {
 
   @Test
   fun `relative import from non-modulepath source does not resolve into modulepath`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
+    fakeProject.settingsManager.update {
+      it.copy(modulepath = listOf(testProjectDir.resolve("lib")))
+    }
     createPklFile("lib/target.pkl", "value = 1")
     createPklFile(
       """
@@ -485,7 +509,9 @@ class GoToDefinitionTest : LspTestBase() {
 
   @Test
   fun `relative import from modulepath source does not escape to filesystem`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("lib"))
+    fakeProject.settingsManager.update {
+      it.copy(modulepath = listOf(testProjectDir.resolve("lib")))
+    }
     createPklFile("External.pkl", "value = 0")
     createPklFile(
       "lib/Foo.pkl",

--- a/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
@@ -20,6 +20,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
+import kotlin.io.path.absolutePathString
 import kotlin.io.path.createParentDirectories
 import kotlin.io.path.name
 import kotlin.io.path.outputStream
@@ -51,7 +52,7 @@ abstract class LspTestBase {
       System.getProperty("pklExecutable")?.let { executablePath ->
         TestLanguageClient.settings["Pkl" to "pkl.cli.path"] = executablePath
         println("pkl is: $executablePath")
-        fakeProject.settingsManager.settings.pklCliPath = Path.of(executablePath)
+        fakeProject.settingsManager.update { it.copy(pklCliPath = Path.of(executablePath)) }
       }
     }
   }
@@ -112,6 +113,9 @@ abstract class LspTestBase {
 
   protected fun createPklFile(contents: String): Path = createPklFile("main.pkl", contents)
 
+  protected fun createPklFile(path: Path, contents: String): Path =
+    createPklFile(path.absolutePathString(), contents)
+
   /**
    * Creates a Pkl file with [contents] in the test project, and also sets the currently active
    * editor to this file's contents.
@@ -142,8 +146,8 @@ abstract class LspTestBase {
   }
 
   /** Creates an archive of Pkl files with contents in the test project. */
-  protected fun createArchive(name: String, entries: Map<String, String>): Path {
-    val file = testProjectDir.resolve(name).also { it.createParentDirectories() }
+  protected fun createArchive(path: Path, entries: Map<String, String>): Path {
+    val file = path.also { it.createParentDirectories() }
     ZipOutputStream(file.outputStream()).use { zip ->
       entries.forEach { (entryName, content) ->
         val zipEntry = ZipEntry(entryName)

--- a/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/SyncProjectsTest.kt
@@ -20,6 +20,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
 import org.pkl.lsp.ast.PklModuleImpl
 import org.pkl.lsp.services.PklWorkspaceState
 
@@ -153,8 +154,10 @@ class SyncProjectsTest : LspTestBase() {
   }
 
   @Test
-  fun `resolve modulepath archive import`() {
-    createArchive("archive.jar", mapOf("dir/target.pkl" to ""))
+  fun `resolve modulepath archive import`(@TempDir tempDir: Path) {
+    val archive = tempDir.resolve("archive.jar")
+    createArchive(archive, mapOf("dir/target.pkl" to ""))
+    fakeProject.settingsManager.update { it.copy(modulepath = listOf(archive)) }
     createPklFile(
       """
       import "modulepath:/dir/target<caret>.pkl"
@@ -170,7 +173,9 @@ class SyncProjectsTest : LspTestBase() {
 
   @Test
   fun `project modulepath is combined with lsp setting`() {
-    fakeProject.settingsManager.settings.modulepath = listOf(testProjectDir.resolve("foo"))
+    fakeProject.settingsManager.update {
+      it.copy(modulepath = listOf(testProjectDir.resolve("foo")))
+    }
     createPklFile("foo/bar.pkl", "")
     createPklFile(
       """


### PR DESCRIPTION
Fixes two issues:

* Use `@TempDir` for new modulepath directories, so that two different tests don't trample on each other.
* Add `settingsManager.update` method which updates its modification count, to ensure that cache keys are invalidated across tests.