### PR TITLE
Gracefully handle glob patterns that match large result sets

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModuleUriAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModuleUriAnalyzer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@ package org.pkl.lsp.analyzers
 
 import java.net.URI
 import java.net.URISyntaxException
+import org.eclipse.lsp4j.DiagnosticSeverity
 import org.pkl.lsp.*
 import org.pkl.lsp.actions.PklDownloadPackageAction
 import org.pkl.lsp.ast.*
@@ -25,6 +26,7 @@ import org.pkl.lsp.packages.dto.Checksums
 import org.pkl.lsp.packages.dto.PackageUri
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.packages.dto.Version
+import org.pkl.lsp.util.GlobResolver
 
 class ModuleUriAnalyzer(project: Project) : Analyzer(project) {
   override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
@@ -79,8 +81,16 @@ class ModuleUriAnalyzer(project: Project) : Analyzer(project) {
       holder.addWarning(element.stringConstant, ErrorMessages.create("cannotGlobTripleDots"))
       return
     }
-    val resolved = element.resolveGlob(context)
-    if (resolved.isEmpty()) {
+    val resolved = element.resolveGlob(context) ?: return
+    if (resolved.exceededMaxElements) {
+      holder.addDiagnostic(
+        element.stringConstant,
+        "This glob pattern matches too many modules; only showing the first ${GlobResolver.MAX_GLOB_ELEMENTS}",
+        element.stringConstant.span,
+        DiagnosticSeverity.Hint,
+      )
+    }
+    if (resolved.elements.isEmpty()) {
       holder.addWarning(element.stringConstant, ErrorMessages.create("globPatternHasNoMatches"))
     }
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -36,6 +36,7 @@ import org.pkl.lsp.type.Type
 import org.pkl.lsp.type.TypeParameterBindings
 import org.pkl.lsp.type.computeResolvedImportType
 import org.pkl.lsp.type.toType
+import org.pkl.lsp.util.GlobResolver
 import org.pkl.lsp.util.ModificationTracker
 
 val PklClass.supertype: PklType?
@@ -302,7 +303,7 @@ inline fun <reified T : PklNode> PklNode.parentOfType(): T? {
 inline fun <reified T : PklNode> PklNode.parentsOfType(): List<T> = parentsOfTypes(T::class)
 
 fun PklImportBase.resolve(context: PklProject?): ModuleResolutionResult =
-  if (isGlob) GlobModuleResolutionResult(moduleUri?.resolveGlob(context) ?: emptyList())
+  if (isGlob) GlobModuleResolutionResult(moduleUri?.resolveGlob(context))
   else SimpleModuleResolutionResult(moduleUri?.resolve(context))
 
 fun PklImportBase.resolveModules(context: PklProject?): List<PklModule> =
@@ -311,18 +312,16 @@ fun PklImportBase.resolveModules(context: PklProject?): List<PklModule> =
       is SimpleModuleResolutionResult -> result.resolved?.let(::listOf) ?: emptyList()
       else -> {
         result as GlobModuleResolutionResult
-        result.resolved
+        if (result.resolved == null || result.resolved.exceededMaxElements) emptyList()
+        else result.resolved.elements.mapNotNull { it.getModule().get() }
       }
     }
   }
 
-fun PklModuleUri.resolveGlob(context: PklProject?): List<PklModule> =
-  this.stringConstant.escapedText()?.let { text ->
-    val futures =
-      resolveGlob(text, text, this, context)?.filter { !it.isDirectory }?.map { it.getModule() }
-        ?: return@let emptyList<PklModule>()
-    futures.sequence().get().filterNotNull()
-  } ?: emptyList()
+fun PklModuleUri.resolveGlob(context: PklProject?): GlobResolver.GlobResult? {
+  val text = this.stringConstant.escapedText() ?: return null
+  return resolveGlob(text, text, this, context)
+}
 
 fun PklModuleUri.resolve(context: PklProject?): PklModule? =
   this.stringConstant.escapedText()?.let { text ->
@@ -349,18 +348,23 @@ class SimpleModuleResolutionResult(val resolved: PklModule?) : ModuleResolutionR
   }
 }
 
-class GlobModuleResolutionResult(val resolved: List<PklModule>) : ModuleResolutionResult() {
+class GlobModuleResolutionResult(val resolved: GlobResolver.GlobResult?) :
+  ModuleResolutionResult() {
   override fun computeResolvedImportType(
     base: PklBaseModule,
     bindings: TypeParameterBindings,
     preserveUnboundedVars: Boolean,
     context: PklProject?,
   ): Type {
-    if (resolved.isEmpty())
+    if (resolved == null) return Type.Unknown
+    if (resolved.exceededMaxElements || resolved.elements.isEmpty())
       return base.mappingType.withTypeArguments(base.stringType, base.moduleType)
     val allTypes =
-      resolved.map {
-        it.computeResolvedImportType(base, bindings, context, preserveUnboundedVars) as Type.Module
+      resolved.elements.mapNotNull { elem ->
+        if (elem.isDirectory) return@mapNotNull null
+        val module = elem.getModule().get() ?: return@mapNotNull null
+        module.computeResolvedImportType(base, bindings, context, preserveUnboundedVars)
+          as Type.Module
       }
     val firstType = allTypes.first()
     val unifiedType =

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -50,7 +50,7 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
     header?.moduleExtendsAmendsClause?.moduleUri
   }
 
-  private val lock = Object()
+  private val lock = Any()
 
   // This is cached at the VirtualFile level
   override fun supermodule(context: PklProject?): PklModule? =

--- a/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklModuleUri.kt
@@ -76,7 +76,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
       moduleUriString: String,
       element: PklModuleUri,
       context: PklProject?,
-    ): List<VirtualFile>? =
+    ): GlobResolver.GlobResult? =
       element.project.cachedValuesManager.getCachedValue(
         "PklModuleUri.resolveGlob($targetUriString, $moduleUriString, ${element.containingFile.path}, ${context?.projectDir})",
         lock,
@@ -161,7 +161,7 @@ class PklModuleUriImpl(project: Project, override val parent: PklNode, override 
       moduleUriString: String,
       element: PklModuleUri,
       context: PklProject?,
-    ): List<VirtualFile>? {
+    ): GlobResolver.GlobResult? {
       val sourceFile = element.containingFile
       val parentDir = sourceFile.parent() ?: return null
       // triple-dot URI's are not supported

--- a/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/GoToDefinitionFeature.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 package org.pkl.lsp.features
 
 import java.net.URI
-import java.util.*
 import java.util.concurrent.CompletableFuture
 import org.eclipse.lsp4j.DefinitionParams
 import org.eclipse.lsp4j.Location
@@ -26,63 +25,99 @@ import org.pkl.lsp.Component
 import org.pkl.lsp.Project
 import org.pkl.lsp.ast.*
 import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.sequence
 import org.pkl.lsp.type.computeThisType
 
 class GoToDefinitionFeature(project: Project) : Component(project) {
+  companion object {
+    val NO_COMPLETIONS: CompletableFuture<Either<List<Location>, List<LocationLink>>> =
+      CompletableFuture.completedFuture(Either.forLeft(emptyList()))
+  }
+
   fun onGoToDefinition(
     params: DefinitionParams
   ): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
-    fun run(mod: PklModule?): Either<List<Location>, List<LocationLink>> {
-      if (mod == null) return Either.forRight(listOf())
-      val line = params.position.line + 1
-      val col = params.position.character + 1
-      val context = mod.containingFile.pklProject
-      val node = mod.findBySpan(line, col) ?: return Either.forRight(listOf())
-      return resolveDeclarations(node, line, col, context)
-    }
     val uri = URI(params.textDocument.uri)
     val file =
       project.virtualFileManager.get(uri)
         ?: return CompletableFuture.completedFuture(Either.forLeft(emptyList()))
-    return file.getModule().thenApply(::run)
+    return file.getModule().thenCompose { doGoToDefinition(it, params) }
   }
 
-  private fun resolveModuleUri(
+  private fun doGoToDefinition(
+    module: PklModule?,
+    params: DefinitionParams,
+  ): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
+    if (module == null) return NO_COMPLETIONS
+    val originalNode =
+      module.findBySpan(params.position.line + 1, params.position.character + 1)
+        ?: return NO_COMPLETIONS
+    val context = module.containingFile.pklProject
+    val parent = originalNode.parent
+    return when {
+      originalNode is PklStringConstant && parent is PklImportBase ->
+        if (parent.isGlob) resolveGlobModuleUri(originalNode, parent, context)
+        else
+          CompletableFuture.completedFuture(
+            Either.forRight(resolveNormalModuleUri(originalNode, parent, context))
+          )
+      else ->
+        CompletableFuture.completedFuture(
+          Either.forLeft(
+            resolveReference(
+              originalNode,
+              params.position.line + 1,
+              params.position.character + 1,
+              context,
+            )
+          )
+        )
+    }
+  }
+
+  private fun resolveGlobModuleUri(
+    originalNode: PklStringConstant,
+    parent: PklModuleUriOwner,
+    context: PklProject?,
+  ): CompletableFuture<Either<List<Location>, List<LocationLink>>> {
+    val stringContentsSpan = originalNode.contentsSpan()
+    val resolved = parent.moduleUri?.resolveGlob(context) ?: return NO_COMPLETIONS
+    val futures = buildList {
+      for (file in resolved.elements) {
+        if (!file.isDirectory) {
+          add(file.getModule())
+        }
+      }
+    }
+    return futures.sequence().thenApply { elems ->
+      Either.forRight(elems.mapNotNull { it?.locationLink(stringContentsSpan) })
+    }
+  }
+
+  private fun resolveNormalModuleUri(
     originalNode: PklStringConstant,
     parent: PklModuleUriOwner,
     context: PklProject?,
   ): List<LocationLink> {
     val stringContentsSpan = originalNode.contentsSpan()
-    if (parent is PklImportBase && parent.isGlob) {
-      val resolved = parent.moduleUri?.resolveGlob(context) ?: return listOf()
-      return resolved.map { it.locationLink(stringContentsSpan) }
-    }
     val resolved = parent.moduleUri?.resolve(context) ?: return listOf()
     return listOf(resolved.locationLink(stringContentsSpan))
   }
 
-  private fun resolveDeclarations(
+  private fun resolveReference(
     originalNode: PklNode,
     line: Int,
     col: Int,
     context: PklProject?,
-  ): Either<List<Location>, List<LocationLink>> {
-    if (originalNode is PklStringConstant && originalNode.parent is PklModuleUriOwner) {
-      return Either.forRight(
-        resolveModuleUri(originalNode, originalNode.parent as PklModuleUriOwner, context)
-      )
+  ): List<Location> {
+    val node = originalNode.resolveReference(line, col, context) ?: return emptyList()
+    return when (node) {
+      is PklThisExpr ->
+        node
+          .computeThisType(project.pklBaseModule, mapOf(), context)
+          .getNode(project, context)
+          ?.let { listOf(it.location) } ?: emptyList()
+      else -> if (node !== originalNode) listOf(node.location) else emptyList()
     }
-    val node =
-      originalNode.resolveReference(line, col, context) ?: return Either.forRight(emptyList())
-    val ret =
-      when (node) {
-        is PklThisExpr ->
-          node
-            .computeThisType(project.pklBaseModule, mapOf(), context)
-            .getNode(project, context)
-            ?.let { listOf(it.location) } ?: emptyList()
-        else -> if (node !== originalNode) listOf(node.location) else emptyList()
-      }
-    return Either.forLeft(ret)
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/util/GlobResolver.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/GlobResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,13 +22,21 @@ import kotlin.collections.ArrayList
 import org.pkl.lsp.VirtualFile
 
 object GlobResolver {
+  data class GlobResult(val elements: List<VirtualFile>, val exceededMaxElements: Boolean)
 
   private val cache = Collections.synchronizedMap(WeakHashMap<String, Pattern>())
 
   private const val NULL = 0.toChar()
 
   /**
-   * The maximum number of [VirtualFile.getChildren] calls to be made when resolving a single glob
+   * The maximum number of elements to collect in a glob pattern.
+   *
+   * If we exceed this number, the resulting [GlobResult.exceededMaxElements] will be set to `true`.
+   */
+  const val MAX_GLOB_ELEMENTS = 300
+
+  /**
+   * The maximum number of [VirtualFile.children] calls to be made when resolving a single glob
    * pattern (prevents an expensive glob from halting the CPU and memory, e.g. a long string of `*`
    * and `..`)
    */
@@ -265,6 +273,8 @@ object GlobResolver {
    * @param listElementCallCount The number of times we have listed children
    * @param isPartial Whether [globPatternParts] represents the whole URI
    * @param result The return value
+   * @return a boolean indicating whether the number of elements in the glob exceeded
+   *   [MAX_GLOB_ELEMENTS].
    */
   private fun expandGlob(
     globPatternParts: List<String>,
@@ -274,7 +284,7 @@ object GlobResolver {
     isPartial: Boolean,
     listChildren: (VirtualFile) -> List<VirtualFile>,
     result: MutableList<VirtualFile>,
-  ) {
+  ): Boolean {
     val patternPart = globPatternParts[idx]
     val isLeaf = idx == globPatternParts.size - 1
     // no expanding needed, carry on
@@ -284,13 +294,14 @@ object GlobResolver {
           "." -> currentDir
           ".." -> currentDir.parent()
           else -> listChildren(currentDir).find { it.name == patternPart }
-        } ?: return
+        } ?: return false
       if (isLeaf) {
+        if (result.size == MAX_GLOB_ELEMENTS) return true
         result.add(child)
-        return
+        return false
       }
       if (child.isDirectory) {
-        expandGlob(
+        return expandGlob(
           globPatternParts,
           idx + 1,
           child,
@@ -303,23 +314,27 @@ object GlobResolver {
     } else {
       val expandedFiles =
         expandGlobPart(currentDir, patternPart, listElementCallCount, listChildren, isPartial)
-          ?: return
+          ?: return false
       for (file in expandedFiles) {
         if (isLeaf) {
+          if (result.size == MAX_GLOB_ELEMENTS) return true
           result.add(file)
         } else if (file.isDirectory) {
-          expandGlob(
-            globPatternParts,
-            idx + 1,
-            file,
-            listElementCallCount,
-            isPartial,
-            listChildren,
-            result,
-          )
+          val exceededMaxElements =
+            expandGlob(
+              globPatternParts,
+              idx + 1,
+              file,
+              listElementCallCount,
+              isPartial,
+              listChildren,
+              result,
+            )
+          if (exceededMaxElements) return true
         }
       }
     }
+    return false
   }
 
   fun resolveRelativeGlob(
@@ -327,13 +342,22 @@ object GlobResolver {
     globPattern: String,
     isPartial: Boolean,
     listChildren: (VirtualFile) -> List<VirtualFile>,
-  ): List<VirtualFile> {
-    if (globPattern.isEmpty()) return listOf(enclosingDirectory)
+  ): GlobResult {
+    if (globPattern.isEmpty()) return GlobResult(listOf(enclosingDirectory), false)
     val result = ArrayList<VirtualFile>()
     val globParts = globPattern.split("/")
-    if (globParts.isEmpty()) return emptyList()
-    expandGlob(globParts, 0, enclosingDirectory, AtomicInteger(0), isPartial, listChildren, result)
-    return result
+    if (globParts.isEmpty()) return GlobResult(emptyList(), false)
+    val exceededMaxElements =
+      expandGlob(
+        globParts,
+        0,
+        enclosingDirectory,
+        AtomicInteger(0),
+        isPartial,
+        listChildren,
+        result,
+      )
+    return GlobResult(result, exceededMaxElements)
   }
 
   fun resolveAbsoluteGlob(
@@ -341,12 +365,13 @@ object GlobResolver {
     globPattern: String,
     isPartial: Boolean,
     listChildren: (VirtualFile) -> List<VirtualFile>,
-  ): List<VirtualFile> {
-    if (globPattern == "/") return listOf(rootFile)
+  ): GlobResult {
+    if (globPattern == "/") return GlobResult(listOf(rootFile), false)
     val result = ArrayList<VirtualFile>()
     val globParts = globPattern.split("/").drop(1)
-    if (globParts.isEmpty()) return emptyList()
-    expandGlob(globParts, 0, rootFile, AtomicInteger(0), isPartial, listChildren, result)
-    return result
+    if (globParts.isEmpty()) return GlobResult(emptyList(), false)
+    val exceededMaxElements =
+      expandGlob(globParts, 0, rootFile, AtomicInteger(0), isPartial, listChildren, result)
+    return GlobResult(result, exceededMaxElements)
   }
 }


### PR DESCRIPTION
This addresses a perf issue where the language client can slow to a halt for glob patterns that match too many modules.

For these cases:

* Stop expanding a glob once 300 elements has been reached
* Show a diagnostics hint that the glob is too large
* Only provide goto definitions for the first 300
* Simplify type analysis to just `Mapping<String, Module>`