### PR TITLE
feat: mirror CLI cache and editor-support fallbacks

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -3,6 +3,27 @@
 This is an implementation of the link:https://microsoft.github.io/language-server-protocol/[Language Server Protocol]
 for link:https://pkl-lang.org[Pkl].
 
+== Cached packages and editor-support data
+
+The LSP looks up cached Pkl packages and tree-sitter native libraries under the same OS-appropriate locations that the Pkl CLI uses:
+
+[cols="1,2,2,2",options="header"]
+|===
+| Concern | Unix (Linux/macOS) | Windows | Legacy fallback
+
+| Package cache
+| `~/.cache/pkl`
+| `%LOCALAPPDATA%/pkl/cache`
+| `~/.pkl/cache`
+
+| Tree-sitter native libraries
+| `~/.local/share/pkl/editor-support/native-libs`
+| `%LOCALAPPDATA%/pkl/editor-support/native-libs`
+| `~/.pkl/editor-support/native-libs`
+|===
+
+If a legacy `~/.pkl/...` location already exists, the LSP keeps using it so existing setups don't need to migrate. See the link:https://pkl-lang.org/main/current/release-notes/0.32.html[Pkl 0.32 release notes] for the full mapping.
+
 == Features
 
 * [x] Diagnostics (WIP)

--- a/src/main/kotlin/org/pkl/lsp/LspUtil.kt
+++ b/src/main/kotlin/org/pkl/lsp/LspUtil.kt
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.pkl.lsp.ast.PklDocCommentOwner
 import org.pkl.lsp.ast.Span
 import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.util.OS
 
 private const val SIGNIFICAND_MASK = 0x000fffffffffffffL
 
@@ -206,7 +207,33 @@ data class Package1CacheDir(override val file: Path) : CacheDir {
 val homeDir: Path
   get() = Path.of(System.getProperty("user.home") ?: throw AssertionError("Cannot find home dir"))
 
-val pklCacheDir: Path = homeDir.resolve(".pkl/cache")
+/**
+ * The default Pkl package cache directory. Prefers the OS-appropriate location – `~/.cache/pkl` on
+ * Unix, `%LOCALAPPDATA%/pkl/cache` on Windows – falling back to the legacy `~/.pkl/cache` when it
+ * already exists. New setups land in the new location; existing setups keep working without
+ * migration.
+ *
+ * Re-evaluates per access so the CLI can create the cache after the LSP starts.
+ *
+ * Keep in sync with `org.pkl.core.util.IoUtils#getDefaultModuleCacheDir`.
+ */
+val pklCacheDir: Path
+  get() {
+    val newLocation: Path? =
+      if (OS.isWindows) {
+        System.getenv("LOCALAPPDATA")
+          ?.takeIf { it.isNotEmpty() }
+          ?.let { Path.of(it, "pkl", "cache") }
+      } else {
+        homeDir.resolve(".cache/pkl")
+      }
+    val legacy = homeDir.resolve(".pkl/cache")
+    return when {
+      newLocation != null && Files.exists(newLocation) -> newLocation
+      Files.exists(legacy) -> legacy
+      else -> newLocation ?: legacy
+    }
+  }
 
 val packages2CacheDir: CacheDir
   get() = Package2CacheDir(pklCacheDir.resolve("package-2"))

--- a/src/main/kotlin/org/pkl/lsp/treesitter/NativeLibrary.kt
+++ b/src/main/kotlin/org/pkl/lsp/treesitter/NativeLibrary.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,27 @@ import org.pkl.lsp.util.OS
 
 data class NativeLibrary(val name: String, val version: String) {
   companion object {
-    private val nativeLibsDir by lazy { homeDir.resolve(".pkl/editor-support/native-libs") }
+    // Keep in sync with the editor-support location in pkl-intellij. Unix lands native libs under
+    // `~/.local/share/pkl/editor-support/native-libs`; Windows lands them under
+    // `%LOCALAPPDATA%/pkl/editor-support/native-libs`. Existing installs keep using
+    // `~/.pkl/editor-support/native-libs` (so an upgrade doesn't trigger a re-download). The lazy
+    // initialiser is fine here – native libs don't move during a session.
+    private val nativeLibsDir by lazy {
+      val newLocation: Path? =
+        if (OS.isWindows) {
+          System.getenv("LOCALAPPDATA")
+            ?.takeIf { it.isNotEmpty() }
+            ?.let { Path.of(it, "pkl", "editor-support", "native-libs") }
+        } else {
+          homeDir.resolve(".local/share/pkl/editor-support/native-libs")
+        }
+      val legacy = homeDir.resolve(".pkl/editor-support/native-libs")
+      when {
+        newLocation != null && Files.exists(newLocation) -> newLocation
+        Files.exists(legacy) -> legacy
+        else -> newLocation ?: legacy
+      }
+    }
   }
 
   private val systemLibraryName = System.mapLibraryName(name)

--- a/src/main/kotlin/org/pkl/lsp/util/OS.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/OS.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,4 +47,8 @@ object OS {
         else -> osArchProperty
       }
     }
+
+  /** Convenience boolean for sites that branch only on Windows vs. Unix. */
+  val isWindows: Boolean
+    get() = osNameProperty.contains("windows")
 }


### PR DESCRIPTION
Look up cached Pkl packages and the tree-sitter native libraries under the OS-appropriate locations the CLI uses: `~/.cache/pkl` and `~/.local/share/pkl/editor-support` on Unix, and `%LOCALAPPDATA%/pkl/...` on Windows.

Fall back to the legacy `~/.pkl/cache` and `~/.pkl/editor-support` when they already exist, so existing setups keep working without migration (and avoid a re-download of native libs on upgrade).

`pklCacheDir` changes from a `val` initialiser to a `get()` so the CLI can create the cache after the LSP starts. Call sites in `PackageManager.kt` and `PklProjectManager.kt` re-evaluate lazily; nothing sits on a hot path.

Aligned with the path conventions in [apple/pkl#1674](https://github.com/apple/pkl/pull/1674) (targeting Pkl 0.32). Fallback logic is replicated locally with a `keep in sync` comment, matching the pattern in `pkl-executor`.

Without this, a user who upgrades their CLI to 0.32 and opens VS Code would lose visibility of cached packages: the LSP would look in `~/.pkl/cache` while the CLI writes to `~/.cache/pkl`.