### PR TITLE
Add analysis for extends clause

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/ImportInfo.kt
+++ b/src/main/kotlin/org/pkl/lsp/ImportInfo.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import org.pkl.lsp.ast.PklImport
+import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.SimpleModuleResolutionResult
+import org.pkl.lsp.ast.Span
+import org.pkl.lsp.ast.escapedText
+import org.pkl.lsp.ast.memberName
+import org.pkl.lsp.ast.resolve
+
+data class ImportPresentation(val uri: String, val memberName: String, val alias: String?) :
+  Comparable<ImportPresentation> {
+  companion object {
+    private val comparator: Comparator<ImportPresentation> =
+      compareBy({ !it.hasSchema }, { it.uri }, { it.alias })
+  }
+
+  val hasSchema: Boolean = uri.contains(":")
+
+  override fun compareTo(other: ImportPresentation): Int = comparator.compare(this, other)
+}
+
+data class ImportInfo(
+  val presentation: ImportPresentation,
+  val module: PklModule?,
+  val span: Span,
+) {
+  companion object {
+    fun create(import: PklImport): ImportInfo? {
+      if (import.isGlob) return null
+      val resolvedModule =
+        (import.resolve(import.containingFile.pklProject) as SimpleModuleResolutionResult).resolved
+      val presentation =
+        ImportPresentation(
+          import.moduleUri!!.stringConstant.escapedText()!!,
+          import.memberName!!,
+          import.identifierName,
+        )
+      return ImportInfo(presentation, resolvedModule, import.span)
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/LspUtil.kt
+++ b/src/main/kotlin/org/pkl/lsp/LspUtil.kt
@@ -27,6 +27,7 @@ import java.util.*
 import java.util.concurrent.CompletableFuture
 import java.util.regex.Pattern
 import kotlin.math.max
+import kotlin.math.min
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import org.eclipse.lsp4j.MarkupContent
@@ -149,11 +150,12 @@ fun String.getIndex(position: Position): Int {
   var currentIndex = 0
   for ((column, line) in lines().withIndex()) {
     if (column == position.line) {
-      return currentIndex + position.character
+      return min(currentIndex + position.character, lastIndex + 1)
     }
     currentIndex += line.length + 1 // + 1 because newline is also a character
   }
-  throw IllegalArgumentException("Invalid position for contents")
+  // according to LSP spec: in case of overflows, just use the very next index.
+  return lastIndex + 1
 }
 
 /**

--- a/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
@@ -418,4 +418,8 @@ open class PklVisitor<R> {
   open fun visitShebangComment(node: PklShebangComment): R? {
     return null
   }
+
+  open fun visitClassExtendsClause(node: PklClassExtendsClause): R? {
+    return null
+  }
 }

--- a/src/main/kotlin/org/pkl/lsp/Refactorings.kt
+++ b/src/main/kotlin/org/pkl/lsp/Refactorings.kt
@@ -1,0 +1,303 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp
+
+import org.eclipse.lsp4j.TextEdit
+import org.pkl.lsp.ast.PklClassMember
+import org.pkl.lsp.ast.PklClassMethod
+import org.pkl.lsp.ast.PklClassProperty
+import org.pkl.lsp.ast.PklConstrainedType
+import org.pkl.lsp.ast.PklDeclaredType
+import org.pkl.lsp.ast.PklDefaultUnionType
+import org.pkl.lsp.ast.PklExpr
+import org.pkl.lsp.ast.PklFunctionType
+import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklModuleType
+import org.pkl.lsp.ast.PklNothingType
+import org.pkl.lsp.ast.PklNullableType
+import org.pkl.lsp.ast.PklParenthesizedType
+import org.pkl.lsp.ast.PklStringLiteralType
+import org.pkl.lsp.ast.PklType
+import org.pkl.lsp.ast.PklTypeCastExpr
+import org.pkl.lsp.ast.PklTypeDefOrModule
+import org.pkl.lsp.ast.PklTypeTestExpr
+import org.pkl.lsp.ast.PklUnionType
+import org.pkl.lsp.ast.PklUnknownType
+import org.pkl.lsp.ast.Terminal
+import org.pkl.lsp.ast.TokenType
+import org.pkl.lsp.ast.appendIdentifier
+import org.pkl.lsp.ast.findOrInsertImport
+import org.pkl.lsp.ast.isInPklBaseModule
+import org.pkl.lsp.ast.resolve
+
+object Refactorings {
+  fun renderMember(
+    myModule: PklModule,
+    parentMember: PklClassMember,
+    importList: MutableList<ImportInfo>,
+    insertedImports: MutableList<TextEdit>,
+    useSnippets: Boolean,
+  ): String {
+    return when (parentMember) {
+      is PklClassProperty -> {
+        renderProperty(myModule, parentMember, importList, insertedImports, useSnippets)
+      }
+
+      is PklClassMethod -> {
+        renderMethod(myModule, parentMember, importList, insertedImports, useSnippets)
+      }
+    }
+  }
+
+  private fun renderProperty(
+    myModule: PklModule,
+    originalProperty: PklClassProperty,
+    imports: MutableList<ImportInfo>,
+    insertedImports: MutableList<TextEdit>,
+    useSnippets: Boolean,
+  ): String {
+    assert(originalProperty.identifierName != null)
+    return buildString {
+      if (appendModifiersWithoutAbstract(originalProperty.modifiers)) {
+        append(" ")
+      }
+      appendIdentifier(originalProperty.identifierName!!)
+      val type = originalProperty.type
+      if (type != null) {
+        append(": ")
+        appendType(type, myModule, imports, insertedImports)
+      }
+      if (useSnippets) {
+        append(" = ${'$'}{1:TODO()}")
+      } else {
+        append(" = TODO()")
+      }
+    }
+  }
+
+  private fun renderMethod(
+    myModule: PklModule,
+    originalMethod: PklClassMethod,
+    imports: MutableList<ImportInfo>,
+    insertedImports: MutableList<TextEdit>,
+    useSnippets: Boolean,
+  ): String {
+    return buildString {
+      if (appendModifiersWithoutAbstract(originalMethod.modifiers)) {
+        append(' ')
+      }
+      append("function ")
+      appendIdentifier(originalMethod.identifierName!!)
+      append('(')
+      originalMethod.methodHeader.parameterList?.let { paramList ->
+        var isFirst = true
+        for (param in paramList.elements) {
+          if (isFirst) {
+            isFirst = false
+          } else {
+            append(", ")
+          }
+          appendIdentifier(param.identifierName!!)
+          val type = param.type
+          if (type != null) {
+            append(": ")
+            appendType(type, myModule, imports, insertedImports)
+          }
+        }
+      }
+      append(')')
+      val returnType = originalMethod.methodHeader.returnType
+      if (returnType != null) {
+        append(": ")
+        appendType(returnType, myModule, imports, insertedImports)
+      }
+      if (useSnippets) {
+        append(" = ${'$'}{1:TODO()}")
+      } else {
+        append(" = TODO()")
+      }
+    }
+  }
+
+  private fun StringBuilder.appendType(
+    type: PklType,
+    myModule: PklModule,
+    imports: MutableList<ImportInfo>,
+    insertedImports: MutableList<TextEdit>,
+  ) {
+    type.accept(PklTypeRenderer(myModule, imports, insertedImports, this))
+  }
+
+  private fun StringBuilder.appendModifiersWithoutAbstract(modifierList: List<Terminal>?): Boolean {
+    var isFirst = true
+    if (modifierList == null) return false
+    for (modifier in modifierList) {
+      if (modifier.type != TokenType.ABSTRACT) {
+        if (isFirst) {
+          isFirst = false
+        } else {
+          append(" ")
+        }
+        append(modifier.text)
+      }
+    }
+    return !isFirst
+  }
+}
+
+class PklTypeRenderer(
+  private val myModule: PklModule,
+  private val imports: MutableList<ImportInfo>,
+  private val insertedImports: MutableList<TextEdit>,
+  private val sb: StringBuilder,
+) : PklVisitor<Unit>() {
+  private fun renderSimpleTypeName(o: PklDeclaredType) {
+    val resolvedType = o.name.resolve(myModule.containingFile.pklProject) as? PklTypeDefOrModule
+    val module = resolvedType?.enclosingModule
+    if (module == myModule) {
+      sb.append(o.name.simpleTypeName.text)
+      return
+    }
+    when {
+      resolvedType == null -> sb.append(o.name.simpleTypeName.identifier!!.text)
+      resolvedType.isInPklBaseModule || resolvedType.enclosingModule == myModule ->
+        sb.appendIdentifier(resolvedType.name)
+
+      else -> {
+        val importName =
+          myModule.findOrInsertImport(resolvedType.enclosingModule!!, imports, insertedImports)
+        sb.appendIdentifier(importName)
+        if (resolvedType !is PklModule) {
+          sb.append(".")
+          sb.appendIdentifier(resolvedType.name)
+        }
+      }
+    }
+  }
+
+  override fun visitDeclaredType(node: PklDeclaredType) {
+    renderSimpleTypeName(node)
+    val argumentList = node.typeArgumentList
+    if (argumentList != null && argumentList.types.isNotEmpty()) {
+      sb.append("<")
+      var isFirst = true
+      for (elem in argumentList.types) {
+        if (isFirst) {
+          isFirst = false
+        } else {
+          sb.append(", ")
+        }
+        elem.accept(this)
+      }
+      sb.append(">")
+    }
+  }
+
+  override fun visitUnknownType(node: PklUnknownType) {
+    sb.append("unknown")
+  }
+
+  override fun visitDefaultUnionType(node: PklDefaultUnionType) {
+    sb.append("*")
+    node.type.accept(this)
+  }
+
+  override fun visitParenthesizedType(node: PklParenthesizedType) {
+    sb.append("(")
+    node.type.accept(this)
+    sb.append(")")
+  }
+
+  override fun visitUnionType(node: PklUnionType) {
+    node.leftType.accept(this)
+    sb.append(" | ")
+    node.rightType.accept(this)
+  }
+
+  override fun visitFunctionType(node: PklFunctionType) {
+    @Suppress("DuplicatedCode") sb.append("(")
+    var isFirst = true
+    for (param in node.parameterList) {
+      if (isFirst) {
+        isFirst = false
+      } else {
+        sb.append(", ")
+      }
+      param.accept(this)
+    }
+    sb.append(") -> ")
+    node.returnType.accept(this)
+  }
+
+  override fun visitModuleType(node: PklModuleType) {
+    val module = node.enclosingModule ?: return
+    if (module == myModule) {
+      sb.append("module")
+    } else {
+      sb.append(myModule.findOrInsertImport(module, imports, insertedImports))
+    }
+  }
+
+  override fun visitNothingType(node: PklNothingType) {
+    sb.append("nothing")
+  }
+
+  override fun visitNullableType(node: PklNullableType) {
+    node.type.accept(this)
+    sb.append("?")
+  }
+
+  override fun visitStringLiteralType(node: PklStringLiteralType) {
+    sb.append(node.text)
+  }
+
+  override fun visitConstrainedType(node: PklConstrainedType) {
+    val myType = node.type ?: return
+    myType.accept(this)
+    sb.append("(")
+    var isFirst = true
+    for (expr in node.exprs) {
+      if (isFirst) {
+        isFirst = false
+      } else {
+        sb.append(", ")
+      }
+      expr.accept(this)
+    }
+    sb.append(")")
+  }
+
+  override fun visitExpr(node: PklExpr) {
+    // TODO this doesn't handle member access.
+    sb.append(node.text)
+  }
+
+  override fun visitTypeTestExpr(node: PklTypeTestExpr) {
+    node.expr?.accept(this)
+    sb.append(' ')
+    sb.append(node.operator.text)
+    sb.append(' ')
+    node.type?.accept(this)
+  }
+
+  override fun visitTypeCastExpr(node: PklTypeCastExpr) {
+    node.expr?.accept(this)
+    sb.append(' ')
+    sb.append(node.operator.text)
+    sb.append(' ')
+    node.type?.accept(this)
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
+++ b/src/main/kotlin/org/pkl/lsp/VirtualFile.kt
@@ -90,6 +90,8 @@ interface VirtualFile : ModificationTracker, CachedValueDataHolder {
 
   fun resolve(path: String): VirtualFile?
 
+  fun relativize(other: VirtualFile): String?
+
   fun getModule(): CompletableFuture<PklModule?>
 
   fun canModify(): Boolean
@@ -171,6 +173,10 @@ class FsFile(override val path: Path, override val project: Project) : BaseFile(
         CachedValue(null, listOf(dependency))
       }
 
+  override fun relativize(other: VirtualFile): String? {
+    return if (other is FsFile) path.parent.relativize(other.path).toString() else null
+  }
+
   override val pklProject: PklProject?
     get() = pklProjectDir?.let { project.pklProjectManager.getPklProject(it) }
 
@@ -238,6 +244,8 @@ class StdlibFile(moduleName: String, override val project: Project) : BaseFile()
       .use { reader -> reader.readText() }
   }
 
+  override fun relativize(other: VirtualFile): String? = null
+
   override fun canModify(): Boolean = false
 }
 
@@ -262,6 +270,10 @@ class HttpsFile(override val uri: URI, override val project: Project) : BaseFile
 
   override fun resolve(path: String): VirtualFile? {
     return project.virtualFileManager.get(uri.resolve(path))
+  }
+
+  override fun relativize(other: VirtualFile): String? {
+    return null
   }
 
   override fun doReadContents(): String {
@@ -335,6 +347,16 @@ class JarFile(override val path: Path, override val uri: URI, override val proje
   override fun canModify(): Boolean = false
 
   private fun getFile(path: Path): VirtualFile? = project.virtualFileManager.get(path)
+
+  override fun relativize(other: VirtualFile): String? {
+    return if (other is JarFile) {
+      try {
+        path.parent.relativize(other.path).toString()
+      } catch (_: IllegalArgumentException) {
+        null
+      }
+    } else null
+  }
 }
 
 class EphemeralFile(private val text: String, override val project: Project) : BaseFile() {
@@ -357,4 +379,6 @@ class EphemeralFile(private val text: String, override val project: Project) : B
   override fun doReadContents(): String = text
 
   override fun canModify(): Boolean = false
+
+  override fun relativize(other: VirtualFile): String? = null
 }

--- a/src/main/kotlin/org/pkl/lsp/actions/PklAddModifierQuickFix.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklAddModifierQuickFix.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,9 +19,12 @@ import java.util.EnumSet
 import org.eclipse.lsp4j.CodeActionDisabled
 import org.eclipse.lsp4j.CodeActionKind
 import org.eclipse.lsp4j.TextEdit
+import org.pkl.lsp.ast.PklClass
 import org.pkl.lsp.ast.PklModifierListOwner
+import org.pkl.lsp.ast.PklModule
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.TokenType
+import org.pkl.lsp.ast.prepend
 
 class PklAddModifierQuickFix(
   override val node: PklModifierListOwner,
@@ -33,12 +36,21 @@ class PklAddModifierQuickFix(
   }
 
   override fun getEdits(): List<TextEdit> {
-    return listOf(insertBefore(getAnchor(), modifier.sourceCode + " "))
+    // if there's no module clause, create one
+    if (node is PklModule && node.header?.moduleClause == null) {
+      return listOf(node.prepend("${modifier.sourceCode} module ${node.name}\n\n"))
+    }
+    return listOf(getAnchor().prepend(modifier.sourceCode + " "))
   }
 
   private fun getAnchor(): PklNode {
-    val sortOrder = modifier.sortOrder
-    return node.modifiers?.find { it.type.sortOrder >= sortOrder } ?: node.terminals.first()
+    val nextModifier = node.modifiers?.find { it.type.sortOrder >= modifier.sortOrder }
+    if (nextModifier != null) return nextModifier
+    return when {
+      node is PklClass -> node.terminals.find { it.type == TokenType.CLASS }!!
+      node is PklModule -> node.header!!.moduleClause!!
+      else -> node.terminals.first()
+    }
   }
 
   override val kind: String = CodeActionKind.QuickFix

--- a/src/main/kotlin/org/pkl/lsp/actions/PklCodeAction.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklCodeAction.kt
@@ -20,7 +20,6 @@ import org.eclipse.lsp4j.CodeActionDisabled
 import org.eclipse.lsp4j.Command
 import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.WorkspaceEdit
-import org.pkl.lsp.LspUtil.toRange
 import org.pkl.lsp.analyzers.PklDiagnostic
 import org.pkl.lsp.ast.PklNode
 import org.pkl.lsp.ast.lspUri
@@ -70,13 +69,6 @@ abstract class PklLocalEditCodeAction(protected open val node: PklNode) : PklCod
           changes = mapOf(node.containingFile.lspUri.toString() to getEdits())
         }
       isPreferred = true
-    }
-  }
-
-  protected fun insertBefore(anchor: PklNode, newText: String): TextEdit {
-    return TextEdit().apply {
-      this.range = anchor.span.firstCaret().toRange()
-      this.newText = newText
     }
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.actions
+
+import org.eclipse.lsp4j.CodeAction
+import org.eclipse.lsp4j.CodeActionDisabled
+import org.eclipse.lsp4j.CodeActionKind
+import org.eclipse.lsp4j.TextEdit
+import org.eclipse.lsp4j.WorkspaceEdit
+import org.pkl.lsp.ErrorMessages
+import org.pkl.lsp.ImportInfo
+import org.pkl.lsp.LspUtil.toRange
+import org.pkl.lsp.Refactorings
+import org.pkl.lsp.analyzers.PklDiagnostic
+import org.pkl.lsp.ast.PklClass
+import org.pkl.lsp.ast.PklClassMember
+import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklTypeDefOrModule
+import org.pkl.lsp.ast.effectiveParentProperties
+import org.pkl.lsp.ast.hasDeclaredMethod
+import org.pkl.lsp.ast.hasDeclaredProperty
+import org.pkl.lsp.ast.lastChildOfClass
+import org.pkl.lsp.ast.lspUri
+import org.pkl.lsp.ast.methods
+
+class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
+  PklLocalEditCodeAction(node) {
+  override fun getEdits(): List<TextEdit> {
+    val myModule = node.enclosingModule ?: return emptyList()
+    val context = myModule.containingFile.pklProject
+    val parentProperties =
+      node.effectiveParentProperties(context)?.values?.filterNot {
+        node.hasDeclaredProperty(it.name) || !it.isFixedOrConstOrAbstract
+      }
+    val parentMethods =
+      node.methods(context)?.values?.filterNot { node.hasDeclaredMethod(it.name) || !it.isAbstract }
+    val parentMembers = (parentProperties ?: listOf()) + (parentMethods ?: listOf())
+    if (node is PklClass) {
+      return node.addMembers(parentMembers)
+    } else {
+      node as PklModule
+      return node.addMembers(parentMembers)
+    }
+  }
+
+  private fun PklTypeDefOrModule.addMembers(parentMembers: List<PklClassMember>): List<TextEdit> {
+    val isModule = this is PklModule
+    val myModule = enclosingModule ?: return emptyList()
+    val imports = myModule.imports.mapNotNull(ImportInfo::create).toMutableList()
+    val insertedImports: MutableList<TextEdit> = mutableListOf()
+    val hasNoClassBody = this is PklClass && this.classBody == null
+    val hasNoOrEmptyClassBody =
+      this is PklClass && this.classBody.let { it == null || it.members.isEmpty() }
+    val lastMember = lastChildOfClass<PklClassMember>()
+    val membersText = buildString {
+      var isFirst = true
+      if (hasNoClassBody) {
+        append(" ")
+      }
+      if (hasNoOrEmptyClassBody) {
+        append("{\n")
+      }
+      if (isModule || lastMember != null) {
+        append("\n\n")
+      }
+      for (parentMember in parentMembers) {
+        val memberText =
+          Refactorings.renderMember(
+            myModule,
+            parentMember,
+            imports,
+            insertedImports,
+            useSnippets = false,
+          )
+        if (isFirst) {
+          isFirst = false
+        } else {
+          append("\n\n")
+        }
+        if (!isModule) {
+          append("  ")
+        }
+        append(memberText)
+      }
+      if (hasNoOrEmptyClassBody) {
+        append("\n}")
+      }
+    }
+    // extends clause guaranteed to exist; quickfix only fires on extending classes/modules
+    val spanToReplace =
+      when {
+        hasNoOrEmptyClassBody ->
+          this.classBody?.span ?: this.extendsClause!!.span.firstSucceedingCaret()
+        lastMember != null -> lastMember.span.firstSucceedingCaret()
+        isModule -> {
+          this.imports.lastOrNull()?.span?.firstSucceedingCaret()
+            ?: this.header!!
+              .moduleExtendsAmendsClause!!
+              .span
+              .firstSucceedingCaret()
+              .endAt(this.span.firstSucceedingCaret())
+        }
+        else -> span.firstSucceedingCaret()
+      }
+    return insertedImports + TextEdit(spanToReplace.toRange(), membersText)
+  }
+
+  override val title: String = ErrorMessages.create("implementMembers")
+
+  override val kind: String = CodeActionKind.QuickFix
+
+  override val disabled: CodeActionDisabled? = null
+
+  override fun toMessage(diagnostic: PklDiagnostic): CodeAction {
+    return super.toMessage(diagnostic).apply {
+      kind = ""
+      edit =
+        WorkspaceEdit().apply {
+          changes = mapOf(node.containingFile.lspUri.toString() to getEdits())
+        }
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
@@ -32,6 +32,7 @@ import org.pkl.lsp.ast.PklModuleMember
 import org.pkl.lsp.ast.PklTypeDefOrModule
 import org.pkl.lsp.ast.effectiveParentProperties
 import org.pkl.lsp.ast.hasDeclaredMethod
+import org.pkl.lsp.ast.hasDeclaredProperty
 import org.pkl.lsp.ast.hasDefault
 import org.pkl.lsp.ast.lastChildOfClass
 import org.pkl.lsp.ast.lspUri
@@ -47,6 +48,7 @@ class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
       node.effectiveParentProperties(context)?.values?.let { properties ->
         buildList {
           for (prop in properties) {
+            if (node.hasDeclaredProperty(prop.name)) continue
             if (prop.isAbstract) {
               add(prop)
             } else if (prop.isFixedOrConst && !prop.hasDefault(base, context)) {

--- a/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
+++ b/src/main/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFix.kt
@@ -28,10 +28,11 @@ import org.pkl.lsp.analyzers.PklDiagnostic
 import org.pkl.lsp.ast.PklClass
 import org.pkl.lsp.ast.PklClassMember
 import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklModuleMember
 import org.pkl.lsp.ast.PklTypeDefOrModule
 import org.pkl.lsp.ast.effectiveParentProperties
 import org.pkl.lsp.ast.hasDeclaredMethod
-import org.pkl.lsp.ast.hasDeclaredProperty
+import org.pkl.lsp.ast.hasDefault
 import org.pkl.lsp.ast.lastChildOfClass
 import org.pkl.lsp.ast.lspUri
 import org.pkl.lsp.ast.methods
@@ -41,9 +42,18 @@ class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
   override fun getEdits(): List<TextEdit> {
     val myModule = node.enclosingModule ?: return emptyList()
     val context = myModule.containingFile.pklProject
+    val base = node.project.pklBaseModule
     val parentProperties =
-      node.effectiveParentProperties(context)?.values?.filterNot {
-        node.hasDeclaredProperty(it.name) || !it.isFixedOrConstOrAbstract
+      node.effectiveParentProperties(context)?.values?.let { properties ->
+        buildList {
+          for (prop in properties) {
+            if (prop.isAbstract) {
+              add(prop)
+            } else if (prop.isFixedOrConst && !prop.hasDefault(base, context)) {
+              add(prop)
+            }
+          }
+        }
       }
     val parentMethods =
       node.methods(context)?.values?.filterNot { node.hasDeclaredMethod(it.name) || !it.isAbstract }
@@ -64,7 +74,11 @@ class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
     val hasNoClassBody = this is PklClass && this.classBody == null
     val hasNoOrEmptyClassBody =
       this is PklClass && this.classBody.let { it == null || it.members.isEmpty() }
-    val lastMember = lastChildOfClass<PklClassMember>()
+    val lastMember =
+      when (this) {
+        is PklClass -> classBody?.lastChildOfClass<PklClassMember>()
+        else -> lastChildOfClass<PklModuleMember>()
+      }
     val membersText = buildString {
       var isFirst = true
       if (hasNoClassBody) {
@@ -73,7 +87,10 @@ class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
       if (hasNoOrEmptyClassBody) {
         append("{\n")
       }
-      if (isModule || lastMember != null) {
+      if (lastMember != null) {
+        append("\n")
+      } else if (isModule) {
+        // amends header followed by no module members.
         append("\n\n")
       }
       for (parentMember in parentMembers) {
@@ -95,8 +112,9 @@ class PklImplementMembersQuickFix(override val node: PklTypeDefOrModule) :
         }
         append(memberText)
       }
+      append("\n")
       if (hasNoOrEmptyClassBody) {
-        append("\n}")
+        append("}")
       }
     }
     // extends clause guaranteed to exist; quickfix only fires on extending classes/modules

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
@@ -36,11 +36,11 @@ import org.pkl.lsp.ast.TokenType
 import org.pkl.lsp.ast.declaredMethods
 import org.pkl.lsp.ast.declaredProperties
 import org.pkl.lsp.ast.effectiveParentProperties
+import org.pkl.lsp.ast.hasDefault
 import org.pkl.lsp.ast.isInStdlib
 import org.pkl.lsp.ast.methods
 import org.pkl.lsp.ast.resolve
 import org.pkl.lsp.packages.dto.PklProject
-import org.pkl.lsp.type.toType
 
 class ExtendsClauseAnalyzer(project: Project) : Analyzer(project) {
   override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
@@ -189,8 +189,7 @@ class ExtendsClauseAnalyzer(project: Project) : Analyzer(project) {
       if (member !is PklClassProperty || !member.isFixedOrConst) continue
       val definedProperty = def.declaredProperties.find { it.name == member.name }
       if (definedProperty != null) continue
-      if (member.expr != null) continue
-      if (member.type.toType(base, mapOf(), context).hasDefault(base, context)) continue
+      if (member.hasDefault(base, context)) continue
 
       // copy Java/Kotlin error message and provide information about just the first missing
       // property.

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
@@ -1,0 +1,277 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.analyzers
+
+import org.pkl.lsp.ErrorMessages
+import org.pkl.lsp.PklBaseModule
+import org.pkl.lsp.Project
+import org.pkl.lsp.actions.PklAddModifierQuickFix
+import org.pkl.lsp.actions.PklImplementMembersQuickFix
+import org.pkl.lsp.ast.PklClass
+import org.pkl.lsp.ast.PklClassExtendsClause
+import org.pkl.lsp.ast.PklClassMember
+import org.pkl.lsp.ast.PklClassProperty
+import org.pkl.lsp.ast.PklDeclaredType
+import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklModuleExtendsAmendsClause
+import org.pkl.lsp.ast.PklModuleType
+import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.PklType
+import org.pkl.lsp.ast.PklTypeAlias
+import org.pkl.lsp.ast.PklTypeDefOrModule
+import org.pkl.lsp.ast.TokenType
+import org.pkl.lsp.ast.declaredMethods
+import org.pkl.lsp.ast.declaredProperties
+import org.pkl.lsp.ast.effectiveParentProperties
+import org.pkl.lsp.ast.isInStdlib
+import org.pkl.lsp.ast.methods
+import org.pkl.lsp.ast.resolve
+import org.pkl.lsp.packages.dto.PklProject
+import org.pkl.lsp.type.toType
+
+class ExtendsClauseAnalyzer(project: Project) : Analyzer(project) {
+  override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean {
+    when (node) {
+      is PklModuleExtendsAmendsClause -> checkModuleExtendsClause(node, diagnosticsHolder)
+      is PklClassExtendsClause -> checkClassExtendsClause(node, diagnosticsHolder, node.type)
+    }
+    return true
+  }
+
+  private fun checkModuleExtendsClause(
+    clause: PklModuleExtendsAmendsClause,
+    holder: DiagnosticsHolder,
+  ) {
+    if (!clause.isExtend) return
+    val moduleUri = clause.moduleUri ?: return
+    val context = clause.enclosingModule?.virtualFile?.pklProject
+    val resolved =
+      moduleUri.resolve(context) ?: return // checked by [PklModuleUriAndVersionAnnotator]
+    if (!resolved.isAbstractOrOpen) {
+      val moduleName = resolved.name
+      holder.addError(
+        moduleUri.stringConstant,
+        ErrorMessages.create("cannotExtendModule", moduleName),
+      ) {
+        if (resolved.virtualFile.canModify()) {
+          actions +=
+            PklAddModifierQuickFix(
+              resolved,
+              ErrorMessages.create("addModuleModifier", moduleName, "open"),
+              TokenType.OPEN,
+            )
+          actions +=
+            PklAddModifierQuickFix(
+              resolved,
+              ErrorMessages.create("addModuleModifier", moduleName, "abstract"),
+              TokenType.ABSTRACT,
+            )
+        }
+      }
+    }
+    val module = clause.enclosingModule ?: return
+    checkParentClassDef(clause, module, project.pklBaseModule, holder, context)
+  }
+
+  private fun checkClassExtendsClause(
+    clause: PklClassExtendsClause,
+    holder: DiagnosticsHolder,
+    supertype: PklType?,
+    visitedAliases: MutableSet<PklTypeAlias> = mutableSetOf(),
+  ) {
+    val context = clause.enclosingModule?.virtualFile?.pklProject
+
+    fun checkSuperclass(clazz: PklClass): Boolean {
+      if (clazz.isExternal && clause.enclosingModule?.isInStdlib != true) {
+        holder.addError(clause, ErrorMessages.create("cannotExtendExternalClass", clazz.name))
+        return true
+      } else if (!clazz.isAbstractOrOpen) {
+        holder.addError(clause, ErrorMessages.create("cannotExtendClass", clazz.name)) {
+          if (clazz.enclosingModule?.virtualFile?.canModify() == true) {
+            actions +=
+              PklAddModifierQuickFix(
+                clazz,
+                ErrorMessages.create("addModuleModifier", clazz.name, "open"),
+                TokenType.OPEN,
+              )
+            actions +=
+              PklAddModifierQuickFix(
+                clazz,
+                ErrorMessages.create("addModuleModifier", clazz.name, "abstract"),
+                TokenType.ABSTRACT,
+              )
+          }
+        }
+        return true
+      }
+      return false
+    }
+
+    fun checkSupermodule(module: PklModule): Boolean {
+      if (module.isAbstractOrOpen) return false
+      val moduleName = module.name
+      holder.addError(clause, ErrorMessages.create("cannotExtendModule", moduleName)) {
+        if (module.virtualFile.canModify()) {
+          actions +=
+            PklAddModifierQuickFix(
+              module,
+              ErrorMessages.create("addModuleModifier", moduleName, "open"),
+              TokenType.OPEN,
+            )
+          actions +=
+            PklAddModifierQuickFix(
+              module,
+              ErrorMessages.create("addModuleModifier", moduleName, "abstract"),
+              TokenType.ABSTRACT,
+            )
+        }
+      }
+      return true
+    }
+
+    var supertypeError = false
+    when (supertype) {
+      null -> {}
+      is PklDeclaredType -> {
+        val typeName = supertype.name
+        val resolved = typeName.resolve(context) ?: return // checked by [PklTypeNameAnnotator]
+
+        when (resolved) {
+          is PklClass -> supertypeError = checkSuperclass(resolved)
+
+          is PklTypeAlias -> {
+            // guard against circular type; e.g. `typealias Foo = Foo`
+            if (visitedAliases.add(resolved)) {
+              checkClassExtendsClause(clause, holder, resolved.type, visitedAliases)
+            }
+            return
+          }
+
+          is PklModule -> supertypeError = checkSupermodule(resolved)
+        }
+      }
+
+      is PklModuleType -> supertypeError = checkSupermodule(clause.enclosingModule ?: return)
+
+      else -> {
+        holder.addError(clause, ErrorMessages.create("cannotExtendType", supertype.text))
+        supertypeError = true
+      }
+    }
+    if (!supertypeError) {
+      val parent = clause.parentOfTypes(PklClass::class) ?: return
+      checkParentClassDef(clause, parent, project.pklBaseModule, holder, context)
+    }
+  }
+
+  private fun checkFixedOrConstMembers(
+    element: PklNode,
+    def: PklTypeDefOrModule,
+    parentMembers: Collection<PklClassMember>,
+    holder: DiagnosticsHolder,
+    base: PklBaseModule,
+    context: PklProject?,
+  ) {
+    for (member in parentMembers) {
+      if (member !is PklClassProperty || !member.isFixedOrConst) continue
+      val definedProperty = def.declaredProperties.find { it.name == member.name }
+      if (definedProperty != null) continue
+      if (member.expr != null) continue
+      if (member.type.toType(base, mapOf(), context).hasDefault(base, context)) continue
+
+      // copy Java/Kotlin error message and provide information about just the first missing
+      // property.
+      val entityName = if (def is PklModule) "module" else "class"
+      val classOrModuleName = def.name
+      val message =
+        ErrorMessages.create(
+          "entityDoesNotDefineDefaultValue",
+          entityName,
+          classOrModuleName,
+          member.name,
+        )
+      holder.addError(element, message) {
+        actions +=
+          PklAddModifierQuickFix(
+            def,
+            ErrorMessages.create("addModuleModifier", classOrModuleName, "abstract"),
+            TokenType.ABSTRACT,
+          )
+        actions += PklImplementMembersQuickFix(def)
+      }
+      return
+    }
+  }
+
+  private fun checkAbstractMembers(
+    element: PklNode,
+    def: PklTypeDefOrModule,
+    parentMembers: Collection<PklClassMember>,
+    holder: DiagnosticsHolder,
+  ): Boolean {
+    for (parentMember in parentMembers) {
+      if (!parentMember.isAbstract) continue
+      val parentName = parentMember.name
+      val definedMember =
+        when (parentMember) {
+          is PklClassProperty -> def.declaredProperties.find { it.name == parentName }
+          else -> def.declaredMethods.find { it.name == parentName }
+        }
+      if (definedMember != null) continue
+
+      // copy Java/Kotlin error message and provide information about just the first missing
+      // method/property.
+      val entityName = if (def is PklModule) "module" else "class"
+      val classOrModuleName = def.name
+      val memberEntityName = if (parentMember is PklClassProperty) "property" else "method"
+      val message =
+        ErrorMessages.create(
+          "entityDoesNotImplementMember",
+          entityName,
+          classOrModuleName,
+          memberEntityName,
+          parentName,
+        )
+      holder.addError(element, message) {
+        actions +=
+          PklAddModifierQuickFix(
+            def,
+            ErrorMessages.create("addModuleModifier", def.name, "abstract"),
+            TokenType.ABSTRACT,
+          )
+        actions += PklImplementMembersQuickFix(def)
+      }
+      return true
+    }
+    return false
+  }
+
+  private fun checkParentClassDef(
+    element: PklNode,
+    def: PklTypeDefOrModule,
+    base: PklBaseModule,
+    holder: DiagnosticsHolder,
+    context: PklProject?,
+  ) {
+    if (def.isAbstract) return
+    val parentProperties = def.effectiveParentProperties(context)?.values ?: emptyList()
+    val parentMethods = def.methods(context)?.values ?: emptyList()
+    val parentMembers = parentProperties + parentMethods
+    if (parentMembers.isEmpty()) return
+    if (checkAbstractMembers(element, def, parentMembers, holder)) return
+    checkFixedOrConstMembers(element, def, parentMembers, holder, base, context)
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ExtendsClauseAnalyzer.kt
@@ -244,7 +244,7 @@ class ExtendsClauseAnalyzer(project: Project) : Analyzer(project) {
           memberEntityName,
           parentName,
         )
-      holder.addError(element, message) {
+      holder.addWarning(element, message) {
         actions +=
           PklAddModifierQuickFix(
             def,

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -21,6 +21,7 @@ import kotlinx.serialization.json.add
 import kotlinx.serialization.json.buildJsonArray
 import org.eclipse.lsp4j.Location
 import org.eclipse.lsp4j.LocationLink
+import org.eclipse.lsp4j.TextEdit
 import org.pkl.lsp.*
 import org.pkl.lsp.FsFile
 import org.pkl.lsp.LspUtil.toRange
@@ -38,6 +39,7 @@ import org.pkl.lsp.type.computeResolvedImportType
 import org.pkl.lsp.type.toType
 import org.pkl.lsp.util.GlobResolver
 import org.pkl.lsp.util.ModificationTracker
+import org.pkl.parser.Lexer
 
 val PklClass.supertype: PklType?
   get() = extends
@@ -48,7 +50,7 @@ fun PklClass.superclass(context: PklProject?): PklClass? {
     is PklModuleType -> null // see PklClass.supermodule
     null ->
       when {
-        isPklBaseAnyClass -> null
+        isPklBaseAnyClass || this == project.pklBaseModule.typedType.ctx -> null
         else -> project.pklBaseModule.typedType.ctx
       }
     else -> unexpectedType(st)
@@ -123,6 +125,10 @@ inline fun PklNode.lastChildMatching(predicate: (PklNode) -> Boolean): PklNode? 
     }
   }
   return null
+}
+
+inline fun <reified T> PklNode.lastChildOfClass(): T? {
+  return lastChildMatching { it is T } as? T
 }
 
 fun PklNode.firstTerminalOfType(type: TokenType): Terminal? {
@@ -431,6 +437,9 @@ fun PklNode.resolveReference(line: Int, col: Int, context: PklProject?): PklNode
             mname.resolve(context)
           } else par.name.resolve(context)
         }
+        is PklClassExtendsClause -> {
+          par.type.resolveReference(line, col, context)
+        }
         else -> this
       }
     else -> this
@@ -659,3 +668,184 @@ fun Appendable.renderParameterList(
 
 fun <T> List<T>.withReplaced(idx: Int, elem: T): List<T> =
   toMutableList().apply { this[idx] = elem }
+
+fun PklTypeDefOrModule.parentTypeDef(context: PklProject?): PklTypeDefOrModule? {
+  return when (this) {
+    is PklClass -> superclass(context) ?: supermodule(context)
+    is PklModule -> supermodule(context)
+    else -> null
+  }
+}
+
+fun PklTypeDefOrModule.methods(context: PklProject?): Map<String, PklClassMethod>? {
+  return when (val def = parentTypeDef(context)) {
+    is PklClass -> def.cache(context).methods
+    is PklModule -> def.cache(context).methods
+    else -> null
+  }
+}
+
+fun PklTypeDefOrModule.effectiveParentProperties(
+  context: PklProject?
+): Map<String, PklClassProperty>? {
+  return when (val def = parentTypeDef(context)) {
+    is PklClass -> def.cache(context).leafProperties
+    is PklModule -> def.cache(context).leafProperties
+    else -> null
+  }
+}
+
+val PklTypeDefOrModule.declaredProperties: List<PklClassProperty>
+  get() =
+    when (this) {
+      is PklClass -> this.properties
+      is PklModule -> this.properties
+      else -> emptyList()
+    }
+
+fun PklTypeDefOrModule.hasDeclaredProperty(name: String): Boolean {
+  for (member in declaredProperties) {
+    if (member.name == name) {
+      return true
+    }
+  }
+  return false
+}
+
+val PklTypeDefOrModule.declaredMethods: List<PklClassMethod>
+  get() =
+    when (this) {
+      is PklClass -> this.methods
+      is PklModule -> this.methods
+      else -> emptyList()
+    }
+
+fun PklTypeDefOrModule.hasDeclaredMethod(name: String?): Boolean {
+  if (name == null) return false
+  for (member in declaredMethods) {
+    if (member.name == name) {
+      return true
+    }
+  }
+  return false
+}
+
+private fun appendNumericSuffix(name: String): String =
+  when (name.last()) {
+    in '0'..'9' -> {
+      val number = name.takeLastWhile { it in '0'..'9' }
+      name.substring(0, name.length - number.length) + (number.toInt() + 1)
+    }
+    else -> name + '2'
+  }
+
+/**
+ * Finds or inserts (in sort order) an import for [module] and returns its member name. Returns
+ * `null` if this operation could not be performed (e.g., due to invalid code).
+ *
+ * Creates dependency-notation URIs, or constructs relative path segments if available.
+ */
+fun PklModule.findOrInsertImport(
+  module: PklModule,
+  imports: MutableList<ImportInfo>,
+  textEdits: MutableList<TextEdit>,
+): String {
+  val defaultImportName = inferImportPropertyName(module.uri.toString()) ?: return "<>"
+  var effectiveImportName: String = defaultImportName
+
+  for (import in imports) {
+    if (import.module == module) return import.presentation.memberName
+
+    if (import.presentation.memberName == effectiveImportName) {
+      effectiveImportName = appendNumericSuffix(effectiveImportName)
+    }
+  }
+
+  val importPath =
+    when {
+      uri.scheme == "package" -> {
+        val myDependency =
+          this.containingFile.pklProject?.myDependencies?.entries?.find {
+            uri.toString().startsWith(it.value.packageUri.toString())
+          }
+        if (myDependency != null) {
+          val pathWithinPackage = uri.fragment
+          "@${myDependency.key}${pathWithinPackage}"
+        } else {
+          // this module comes from is a package, but the originating module doesn't declare this as
+          // a dependency.
+          // bail out and just import the `package://` URI
+          uri.toString()
+        }
+      }
+      else -> this.virtualFile.relativize(module.virtualFile) ?: module.uri.toString()
+    }
+
+  val importText =
+    if (effectiveImportName == defaultImportName) {
+      "import \"${importPath}\""
+    } else {
+      "import \"${importPath}\" as ${Lexer.maybeQuoteIdentifier(effectiveImportName)}"
+    }
+
+  val importPresentation =
+    ImportPresentation(
+      importPath,
+      effectiveImportName,
+      if (effectiveImportName == defaultImportName) null else effectiveImportName,
+    )
+  var newElementAdded = false
+  for (oldImport in imports) {
+    if (importPresentation < oldImport.presentation) {
+      textEdits +=
+        TextEdit().apply {
+          newText = importText + "\n"
+          range = oldImport.span.firstCaret().toRange()
+        }
+      imports += ImportInfo(importPresentation, module, oldImport.span.firstCaret())
+      newElementAdded = true
+      break
+    }
+  }
+
+  if (!newElementAdded) {
+    val insertAfter = this.imports.lastOrNull()?.span ?: this.header?.span
+    if (insertAfter != null) {
+      val span = insertAfter.firstSucceedingCaret()
+      textEdits +=
+        TextEdit().apply {
+          range = span.toRange()
+          newText = "\n" + importText
+        }
+      imports += ImportInfo(importPresentation, module, span)
+    } else {
+      val span = this.span.firstCaret()
+      textEdits +=
+        TextEdit().apply {
+          range = span.toRange()
+          newText = importText + "\n"
+        }
+      imports += ImportInfo(importPresentation, module, span)
+    }
+  }
+
+  return effectiveImportName
+}
+
+fun PklNode.prepend(newText: String): TextEdit {
+  return TextEdit().apply {
+    this.range = span.firstCaret().toRange()
+    this.newText = newText
+  }
+}
+
+fun PklNode.append(newText: String): TextEdit {
+  return TextEdit().apply {
+    this.range = span.firstSucceedingCaret().toRange()
+    this.newText = newText
+  }
+}
+
+fun StringBuilder.appendIdentifier(identifier: String) {
+  append(Lexer.maybeQuoteIdentifier(identifier))
+}

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -752,13 +752,12 @@ fun PklModule.findOrInsertImport(
 ): String {
   val defaultImportName = inferImportPropertyName(module.uri.toString()) ?: return "<>"
   var effectiveImportName: String = defaultImportName
-
   for (import in imports) {
     if (import.module == module) return import.presentation.memberName
-
-    if (import.presentation.memberName == effectiveImportName) {
-      effectiveImportName = appendNumericSuffix(effectiveImportName)
-    }
+  }
+  val existingImportNames = imports.mapTo(mutableSetOf()) { it.presentation.memberName }
+  while (existingImportNames.contains(effectiveImportName)) {
+    effectiveImportName = appendNumericSuffix(effectiveImportName)
   }
 
   val importPath =
@@ -844,6 +843,10 @@ fun PklNode.append(newText: String): TextEdit {
     this.range = span.firstSucceedingCaret().toRange()
     this.newText = newText
   }
+}
+
+fun PklClassProperty.hasDefault(base: PklBaseModule, context: PklProject?): Boolean {
+  return expr != null || type.toType(base, mapOf(), context).hasDefault(base, context)
 }
 
 fun StringBuilder.appendIdentifier(identifier: String) {

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -89,11 +89,6 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
 
   override val methods: List<PklClassMethod> by lazy { members.filterIsInstance<PklClassMethod>() }
 
-  override val shortDisplayName: String by lazy {
-    header?.moduleClause?.shortDisplayName
-      ?: uri.toString().substringAfterLast('/').replace(".pkl", "")
-  }
-
   override val moduleName: String by lazy {
     header?.moduleClause?.moduleName ?: uri.toString().substringAfterLast('/').replace(".pkl", "")
   }

--- a/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/ModuleOrClass.kt
@@ -32,6 +32,12 @@ class PklModuleImpl(override val ctx: Node, override val virtualFile: VirtualFil
 
   override var index: Int = 0
 
+  override val name: String
+    get() {
+      return header?.moduleClause?.shortDisplayName
+        ?: uri.toString().substringAfterLast('/').replace(".pkl", "")
+    }
+
   override val isAmend: Boolean by lazy { header?.moduleExtendsAmendsClause?.isAmend ?: false }
 
   override val header: PklModuleHeader? by lazy { getChild(PklModuleHeaderImpl::class) }
@@ -236,7 +242,7 @@ class PklClassImpl(
   override val parent: PklNode,
   override val ctx: Node,
 ) : AbstractPklNode(project, parent, ctx), PklClass {
-  override val extends: PklType? by lazy { getChild(PklDeclaredTypeImpl::class) }
+  override val extends: PklType? by lazy { extendsClause?.type }
 
   override val annotations: List<PklAnnotation>? by lazy { getChildren(PklAnnotationImpl::class) }
 
@@ -262,6 +268,10 @@ class PklClassImpl(
   }
 
   override val methods: List<PklClassMethod> by lazy { members.filterIsInstance<PklClassMethod>() }
+
+  override val extendsClause: PklClassExtendsClause? by lazy {
+    getChild(PklClassExtendsClauseImpl::class)
+  }
 
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitClass(this)
@@ -311,4 +321,16 @@ class PklTypeParameterImpl(
   override fun <R> accept(visitor: PklVisitor<R>): R? {
     return visitor.visitTypeParameter(this)
   }
+}
+
+class PklClassExtendsClauseImpl(
+  override val project: Project,
+  override val parent: PklNode,
+  override val ctx: Node,
+) : AbstractPklNode(project, parent, ctx), PklClassExtendsClause {
+  override fun <R> accept(visitor: PklVisitor<R>): R? {
+    return visitor.visitClassExtendsClause(this)
+  }
+
+  override val type: PklType = PklDeclaredTypeImpl(project, this, ctx, false)
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -167,6 +167,9 @@ interface PklModifierListOwner : PklNode {
   val isFixedOrConst: Boolean
     get() = hasAnyModifier(TokenType.CONST, TokenType.FIXED)
 
+  val isFixedOrConstOrAbstract: Boolean
+    get() = hasAnyModifier(TokenType.CONST, TokenType.FIXED, TokenType.ABSTRACT)
+
   val isAbstractOrOpen: Boolean
     get() = hasAnyModifier(TokenType.ABSTRACT, TokenType.OPEN)
 
@@ -212,7 +215,8 @@ interface PklDocCommentOwner : PklNode {
 
 sealed interface PklNavigableElement : PklNode
 
-sealed interface PklTypeDefOrModule : PklNavigableElement, PklModifierListOwner, PklDocCommentOwner
+sealed interface PklTypeDefOrModule :
+  PklNavigableElement, PklModifierListOwner, PklDocCommentOwner, PklNamedNode
 
 interface PklModule : PklTypeDefOrModule {
   val uri: URI
@@ -234,7 +238,6 @@ interface PklModule : PklTypeDefOrModule {
 
   fun cache(context: PklProject?): ModuleMemberCache
 
-  val shortDisplayName: String
   val moduleName: String
 
   /** The package dependencies of this module. */
@@ -295,8 +298,13 @@ interface PklClass : PklTypeDef, IdentifierOwner, PklNamedNode {
   val members: List<PklClassMember>
   val properties: List<PklClassProperty>
   val methods: List<PklClassMethod>
+  val extendsClause: PklClassExtendsClause?
 
   fun cache(context: PklProject?): ClassMemberCache
+}
+
+interface PklClassExtendsClause : PklNode {
+  val type: PklType
 }
 
 interface PklClassBody : PklNode {
@@ -887,7 +895,7 @@ fun Node.toNode(project: Project, parent: PklNode?): PklNode? {
     "clazz" -> PklClassImpl(project, parent!!, this)
     "classBody" -> PklClassBodyImpl(project, parent!!, this)
     // This is kinda of a hack but works because they have the same children
-    "classExtendsClause" -> PklDeclaredTypeImpl(project, parent!!, this, false)
+    "classExtendsClause" -> PklClassExtendsClauseImpl(project, parent!!, this)
     "classProperty" -> PklClassPropertyImpl(project, parent!!, this)
     "methodHeader" -> PklMethodHeaderImpl(project, parent!!, this)
     "classMethod" -> PklClassMethodImpl(project, parent!!, this)

--- a/src/main/kotlin/org/pkl/lsp/ast/Span.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Span.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024-2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,6 +34,9 @@ data class Span(val beginLine: Int, val beginCol: Int, val endLine: Int, val end
 
   /** Returns a zero-length span at the first position of this span. */
   fun firstCaret(): Span = Span(beginLine, beginCol, beginLine, beginCol)
+
+  /** Returns a zero-length span at the first position after this. */
+  fun firstSucceedingCaret(): Span = Span(endLine, endCol + 1, endLine, endCol + 1)
 
   fun drop(offset: Int): Span = Span(beginLine, beginCol + offset, endLine, endCol)
 

--- a/src/main/kotlin/org/pkl/lsp/completion/ImplementMethodCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/ImplementMethodCompletionProvider.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.completion
+
+import org.eclipse.lsp4j.CompletionItem
+import org.eclipse.lsp4j.CompletionItemKind
+import org.eclipse.lsp4j.CompletionParams
+import org.eclipse.lsp4j.InsertTextFormat
+import org.eclipse.lsp4j.MarkupContent
+import org.eclipse.lsp4j.MarkupKind
+import org.eclipse.lsp4j.TextEdit
+import org.pkl.lsp.Component
+import org.pkl.lsp.ImportInfo
+import org.pkl.lsp.ImportInfo.Companion.create
+import org.pkl.lsp.Project
+import org.pkl.lsp.Refactorings
+import org.pkl.lsp.ast.PklClassBody
+import org.pkl.lsp.ast.PklClassMethod
+import org.pkl.lsp.ast.PklModule
+import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.PklTypeAlias
+import org.pkl.lsp.ast.PklTypeDefOrModule
+import org.pkl.lsp.ast.appendIdentifier
+import org.pkl.lsp.ast.hasDeclaredMethod
+import org.pkl.lsp.ast.methods
+import org.pkl.lsp.ast.parentOfType
+
+class ImplementMethodCompletionProvider(project: Project) : Component(project), CompletionProvider {
+  override fun getCompletions(
+    node: PklNode,
+    params: CompletionParams,
+    collector: MutableList<CompletionItem>,
+  ) {
+    if (node.parent !is PklClassBody && node.parent !is PklModule) return
+    val def = node.parentOfType<PklTypeDefOrModule>() ?: return
+    if (def is PklTypeAlias) return
+    val module = def.enclosingModule ?: return
+    val context = def.containingFile.pklProject
+    // only offer completions for abstract methods for now.
+    // completions for other methods might encourage overriding functions that are meant to be
+    // closed
+    // (Pkl does not have open/closed functions)
+    val parentMethods =
+      def.methods(context)?.values?.filterNot { def.hasDeclaredMethod(it.name) || !it.isAbstract }
+        ?: return
+
+    for (method in parentMethods) {
+      if (method.identifierName == null) continue
+      collector.add(
+        CompletionItem().apply {
+          val insertedImports = mutableListOf<TextEdit>()
+          val imports = module.imports.mapNotNull(ImportInfo::create).toMutableList()
+          val memberText =
+            Refactorings.renderMember(module, method, imports, insertedImports, useSnippets = true)
+          val effectiveDocComment = method.effectiveDocComment(context)
+          this.label = renderCompletionText(method)
+          this.kind = CompletionItemKind.Method
+          this.insertTextFormat = InsertTextFormat.Snippet
+          this.insertText = memberText
+          this.additionalTextEdits = insertedImports
+          if (effectiveDocComment != null) {
+            setDocumentation(MarkupContent(effectiveDocComment, MarkupKind.MARKDOWN))
+          }
+        }
+      )
+    }
+  }
+
+  fun renderCompletionText(method: PklClassMethod): String {
+    return buildString {
+      append("function ")
+      // `name` guaranteed to exist (we only provide completions for members that have names)
+      appendIdentifier(method.identifierName!!)
+      append("(")
+      method.methodHeader.parameterList?.elements?.let { params ->
+        var isFirst = true
+        for (param in params) {
+          if (isFirst) {
+            isFirst = false
+          } else {
+            append(", ")
+          }
+          appendIdentifier(param.identifierName!!)
+          param.type?.let { type ->
+            append(": ")
+            append(type.text)
+          }
+        }
+      }
+      append(")")
+      method.methodHeader.returnType?.let { type ->
+        append(": ")
+        append(type.text)
+      }
+      append(" = …")
+    }
+  }
+}

--- a/src/main/kotlin/org/pkl/lsp/documentation/toMarkdown.kt
+++ b/src/main/kotlin/org/pkl/lsp/documentation/toMarkdown.kt
@@ -106,7 +106,7 @@ private fun PklNode.doRenderMarkdown(originalNode: PklNode?, context: PklProject
           append(it.doRenderMarkdown(originalNode, context))
         }
       }
-    is PklModule -> header?.doRenderMarkdown(originalNode, context) ?: "module $moduleName"
+    is PklModule -> header?.doRenderMarkdown(originalNode, context) ?: "module $name"
     is PklModuleHeader ->
       buildString {
         append(modifiers.render())
@@ -119,8 +119,7 @@ private fun PklNode.doRenderMarkdown(originalNode: PklNode?, context: PklProject
           append(it.moduleUri!!.stringConstant.text)
         }
       }
-    is PklModuleClause ->
-      buildString { append(moduleName ?: enclosingModule?.moduleName ?: "<module>") }
+    is PklModuleClause -> buildString { append(moduleName ?: enclosingModule?.name ?: "<module>") }
     is PklImport ->
       buildString {
         if (isGlob) {
@@ -236,7 +235,7 @@ private fun showDocCommentAndModule(node: PklNode?, text: String, context: PklPr
       append("---")
       appendLine()
       appendLine()
-      append("in [${module.moduleName}](${module.getLocationUri(forDocs = true)})")
+      append("in [${module.name}](${module.getLocationUri(forDocs = true)})")
     }
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/documentation/toMarkdown.kt
+++ b/src/main/kotlin/org/pkl/lsp/documentation/toMarkdown.kt
@@ -106,7 +106,7 @@ private fun PklNode.doRenderMarkdown(originalNode: PklNode?, context: PklProject
           append(it.doRenderMarkdown(originalNode, context))
         }
       }
-    is PklModule -> header?.doRenderMarkdown(originalNode, context) ?: "module $name"
+    is PklModule -> header?.doRenderMarkdown(originalNode, context) ?: "module $moduleName"
     is PklModuleHeader ->
       buildString {
         append(modifiers.render())
@@ -119,7 +119,8 @@ private fun PklNode.doRenderMarkdown(originalNode: PklNode?, context: PklProject
           append(it.moduleUri!!.stringConstant.text)
         }
       }
-    is PklModuleClause -> buildString { append(moduleName ?: enclosingModule?.name ?: "<module>") }
+    is PklModuleClause ->
+      buildString { append(moduleName ?: enclosingModule?.moduleName ?: "<module>") }
     is PklImport ->
       buildString {
         if (isGlob) {
@@ -235,7 +236,7 @@ private fun showDocCommentAndModule(node: PklNode?, text: String, context: PklPr
       append("---")
       appendLine()
       appendLine()
-      append("in [${module.name}](${module.getLocationUri(forDocs = true)})")
+      append("in [${module.moduleName}](${module.getLocationUri(forDocs = true)})")
     }
   }
 }

--- a/src/main/kotlin/org/pkl/lsp/features/CompletionFeature.kt
+++ b/src/main/kotlin/org/pkl/lsp/features/CompletionFeature.kt
@@ -31,6 +31,7 @@ class CompletionFeature(project: Project) : Component(project) {
       QualifiedAccessCompletionProvider(project),
       UnqualifiedAccessCompletionProvider(project),
       StringLiteralTypeCompletionProvider(project),
+      ImplementMethodCompletionProvider(project),
     )
 
   fun onCompletion(

--- a/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
+++ b/src/main/kotlin/org/pkl/lsp/services/DiagnosticsManager.kt
@@ -42,6 +42,7 @@ class DiagnosticsManager(project: Project) : Component(project) {
       TypeNameAnalyzer(project),
       TypeAnalyzer(project),
       UnusedLocalDefinitionAnalyzer(project),
+      ExtendsClauseAnalyzer(project),
     )
 
   private val openFiles: MutableMap<URI, Boolean> = ConcurrentHashMap()
@@ -64,7 +65,9 @@ class DiagnosticsManager(project: Project) : Component(project) {
         openFiles[event.file] = true
       }
       is TextDocumentEvent.Changed -> {
-        doPublishDiagnostics(event.file)
+        for (file in openFiles.keys) {
+          doPublishDiagnostics(file)
+        }
       }
       is TextDocumentEvent.Closed -> {
         openFiles.remove(event.file)

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
@@ -33,8 +33,8 @@ fun PklNode?.computeResolvedImportType(
 
   return RecursionManager.doPreventingRecursion(this, "computeResolvedImportType", Type.Unknown) {
     when (this) {
-      is PklModule -> Type.module(this, shortDisplayName, context)
-      is PklClass -> Type.Class.create(this)
+      is PklModule -> Type.module(this, name, context)
+      is PklClass -> Type.Class(this)
       is PklTypeAlias -> Type.alias(this, context)
       is PklMethod ->
         when {

--- a/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/ComputeDefinitionType.kt
@@ -34,7 +34,7 @@ fun PklNode?.computeResolvedImportType(
   return RecursionManager.doPreventingRecursion(this, "computeResolvedImportType", Type.Unknown) {
     when (this) {
       is PklModule -> Type.module(this, name, context)
-      is PklClass -> Type.Class(this)
+      is PklClass -> Type.Class.create(this)
       is PklTypeAlias -> Type.alias(this, context)
       is PklMethod ->
         when {
@@ -171,7 +171,6 @@ fun PklNode?.computeResolvedImportType(
                         getFunctionParameterType(this, identifierOwner, functionType, base, context)
                       }
                       is PklObjectBodyOwner -> {
-                        @Suppress("BooleanLiteralArgument")
                         val functionType =
                           objectBodyOwner.computeResolvedImportType(
                             base,

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -510,7 +510,7 @@ sealed class Type(val constraints: List<ConstraintExpr> = listOf()) {
     }
 
     fun supermodule(context: PklProject?): Module? =
-      ctx.supermodule(context)?.let { module(it, it.shortDisplayName, context) }
+      ctx.supermodule(context)?.let { module(it, it.name, context) }
 
     // assumes `!this.isSubtypeOf(type)`
     override fun hasCommonSubtypeWith(

--- a/src/main/kotlin/org/pkl/lsp/util/Edits.kt
+++ b/src/main/kotlin/org/pkl/lsp/util/Edits.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,8 +32,13 @@ object Edits {
   }
 
   fun apply(original: String, edits: List<Edit>): String {
+    val sorted =
+      edits.sortedWith(
+        compareByDescending<Edit> { it.range?.start?.line }
+          .thenByDescending { it.range?.start?.character }
+      )
     var result = original
-    for (change in edits) {
+    for (change in sorted) {
       if (change.range == null) {
         result = change.text
       } else {

--- a/src/main/resources/org/pkl/lsp/errorMessages.properties
+++ b/src/main/resources/org/pkl/lsp/errorMessages.properties
@@ -220,3 +220,27 @@ Actual: {1}
 
 invalidReferenceTypeWithConstraint=\
 `pkl.ref#Reference` type annotations may not contain type constraints.
+
+cannotExtendModule=\
+Cannot extend module ''{0}''
+
+cannotExtendClass=\
+Cannot extend class ''{0}''
+
+cannotExtendExternalClass=\
+Cannot extend external class ''{0}''
+
+cannotExtendType=\
+Cannot extend type ''{0}''
+
+addModuleModifier=\
+Make ''{0}'' {1}
+
+entityDoesNotImplementMember=\
+{0} {1} is not abstract and does not implement {2} ''{3}''
+
+entityDoesNotDefineDefaultValue=\
+{0} {1} is not abstract and does not define a default value for property ''{2}''
+
+implementMembers=\
+Implement members

--- a/src/test/files/DiagnosticsSnippetTests/input/extendsClause/abstractMemberNotImplemented.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/extendsClause/abstractMemberNotImplemented.pkl
@@ -1,0 +1,5 @@
+abstract class Base {
+  abstract function bar(): Int
+}
+
+class MyClass extends Base

--- a/src/test/files/DiagnosticsSnippetTests/input/extendsClause/abstractModuleMemberNotImplemented.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/extendsClause/abstractModuleMemberNotImplemented.pkl
@@ -1,0 +1,1 @@
+extends "../../inputHelpers/extendsClause/abstractModule.pkl"

--- a/src/test/files/DiagnosticsSnippetTests/input/extendsClause/extendsNonOpenClass.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/extendsClause/extendsNonOpenClass.pkl
@@ -1,0 +1,3 @@
+class Base
+
+class MyClass extends Base

--- a/src/test/files/DiagnosticsSnippetTests/input/extendsClause/extendsNonOpenModule.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/extendsClause/extendsNonOpenModule.pkl
@@ -1,0 +1,1 @@
+extends "../../inputHelpers/extendsClause/closedModule.pkl"

--- a/src/test/files/DiagnosticsSnippetTests/input/extendsClause/fixedConstHasNoDefault.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/extendsClause/fixedConstHasNoDefault.pkl
@@ -1,0 +1,5 @@
+abstract class Base {
+  const bar: Int
+}
+
+class MyClass extends Base

--- a/src/test/files/DiagnosticsSnippetTests/inputHelpers/extendsClause/abstractModule.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputHelpers/extendsClause/abstractModule.pkl
@@ -1,0 +1,3 @@
+abstract module abstractModule
+
+abstract function bar(): Int

--- a/src/test/files/DiagnosticsSnippetTests/inputHelpers/extendsClause/closedModule.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputHelpers/extendsClause/closedModule.pkl
@@ -1,0 +1,1 @@
+module closedModule

--- a/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/childImplementsAllMembers.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/childImplementsAllMembers.pkl
@@ -1,0 +1,9 @@
+abstract module Foo
+
+abstract class Base {
+  abstract function name(): String
+}
+
+class Child extends Base {
+  function name(): String = "Bob"
+}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingAbstractMethod.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingAbstractMethod.pkl
@@ -1,0 +1,7 @@
+abstract module Foo
+
+abstract class Base {
+  abstract function greet(): String
+}
+
+class Child extends Base {}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingAbstractProperty.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingAbstractProperty.pkl
@@ -1,0 +1,7 @@
+abstract module Foo
+
+abstract class Base {
+  abstract name: String
+}
+
+class Child extends Base {}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingConstDefaultProperty.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingConstDefaultProperty.pkl
@@ -1,0 +1,7 @@
+abstract module Foo
+
+abstract class Base {
+  const name: String
+}
+
+class Child extends Base {}

--- a/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingFixedPropertyDefault.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/inputs/extendsClause/missingFixedPropertyDefault.pkl
@@ -1,0 +1,7 @@
+abstract module Foo
+
+abstract class Base {
+  fixed name: String
+}
+
+class Child extends Base {}

--- a/src/test/files/DiagnosticsSnippetTests/output/extendsClause/abstractMemberNotImplemented.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/extendsClause/abstractMemberNotImplemented.txt
@@ -1,0 +1,8 @@
+ abstract class Base {
+   abstract function bar(): Int
+ }
+ 
+ class MyClass extends Base
+               ^^^^^^^^^^^^
+| Warning: class MyClass is not abstract and does not implement method 'bar'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/output/extendsClause/abstractModuleMemberNotImplemented.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/extendsClause/abstractModuleMemberNotImplemented.txt
@@ -1,0 +1,4 @@
+ extends "../../inputHelpers/extendsClause/abstractModule.pkl"
+ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+| Warning: module abstractModuleMemberNotImplemented is not abstract and does not implement method 'bar'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/output/extendsClause/extendsNonOpenClass.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/extendsClause/extendsNonOpenClass.txt
@@ -1,0 +1,6 @@
+ class Base
+ 
+ class MyClass extends Base
+               ^^^^^^^^^^^^
+| Error: Cannot extend class 'Base'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/output/extendsClause/extendsNonOpenModule.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/extendsClause/extendsNonOpenModule.txt
@@ -1,0 +1,4 @@
+ extends "../../inputHelpers/extendsClause/closedModule.pkl"
+         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+| Error: Cannot extend module 'closedModule'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/output/extendsClause/fixedConstHasNoDefault.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/extendsClause/fixedConstHasNoDefault.txt
@@ -1,0 +1,8 @@
+ abstract class Base {
+   const bar: Int
+ }
+ 
+ class MyClass extends Base
+               ^^^^^^^^^^^^
+| Error: class MyClass is not abstract and does not define a default value for property 'bar'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/childImplementsAllMembers.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/childImplementsAllMembers.txt
@@ -1,0 +1,10 @@
+ abstract module Foo
+ 
+ abstract class Base {
+   abstract function name(): String
+ }
+ 
+ class Child extends Base {
+   function name(): String = "Bob"
+ }
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingAbstractMethod.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingAbstractMethod.txt
@@ -1,0 +1,10 @@
+ abstract module Foo
+ 
+ abstract class Base {
+   abstract function greet(): String
+ }
+ 
+ class Child extends Base {}
+             ^^^^^^^^^^^^
+| Error: class Child is not abstract and does not implement method 'greet'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingAbstractProperty.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingAbstractProperty.txt
@@ -1,0 +1,10 @@
+ abstract module Foo
+ 
+ abstract class Base {
+   abstract name: String
+ }
+ 
+ class Child extends Base {}
+             ^^^^^^^^^^^^
+| Error: class Child is not abstract and does not implement property 'name'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingConstDefaultProperty.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingConstDefaultProperty.txt
@@ -1,0 +1,10 @@
+ abstract module Foo
+ 
+ abstract class Base {
+   const name: String
+ }
+ 
+ class Child extends Base {}
+             ^^^^^^^^^^^^
+| Error: class Child is not abstract and does not define a default value for property 'name'
+ 

--- a/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingFixedPropertyDefault.txt
+++ b/src/test/files/DiagnosticsSnippetTests/outputs/extendsClause/missingFixedPropertyDefault.txt
@@ -1,0 +1,10 @@
+ abstract module Foo
+ 
+ abstract class Base {
+   fixed name: String
+ }
+ 
+ class Child extends Base {}
+             ^^^^^^^^^^^^
+| Error: class Child is not abstract and does not define a default value for property 'name'
+ 

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
@@ -72,7 +72,7 @@ class GoToDefinitionPackagesTest : LspTestBase() {
     )
     val resolved = goToDefinition().single()
     assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
-    assertThat(resolved.enclosingModule!!.name).isEqualTo("k8s.api.apps.v1.Deployment")
+    assertThat(resolved.enclosingModule!!.moduleName).isEqualTo("k8s.api.apps.v1.Deployment")
   }
 
   @Test

--- a/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/GoToDefinitionPackagesTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2024 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2024-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,8 +46,8 @@ class GoToDefinitionPackagesTest : LspTestBase() {
   fun `resolve package asset uri`() {
     createPklFile(
       """
-    amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2#/AppEnvCluster.pkl<caret>"
-    """
+      amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2#/AppEnvCluster.pkl<caret>"
+      """
         .trimIndent()
     )
     val resolved = goToDefinition().single()
@@ -60,19 +60,19 @@ class GoToDefinitionPackagesTest : LspTestBase() {
   fun `resolve package dependency`() {
     createPklFile(
       """
-    amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2#/AppEnvCluster.pkl"
-    
-    deployments {
-      ["foo"] {
-        spec<caret> {}
+      amends "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2#/AppEnvCluster.pkl"
+
+      deployments {
+        ["foo"] {
+          spec<caret> {}
+        }
       }
-    }
-    """
+      """
         .trimIndent()
     )
     val resolved = goToDefinition().single()
     assertThat(resolved).isInstanceOf(PklClassProperty::class.java)
-    assertThat(resolved.enclosingModule!!.moduleName).isEqualTo("k8s.api.apps.v1.Deployment")
+    assertThat(resolved.enclosingModule!!.name).isEqualTo("k8s.api.apps.v1.Deployment")
   }
 
   @Test
@@ -80,7 +80,7 @@ class GoToDefinitionPackagesTest : LspTestBase() {
     createPklFile(
       """
       import* "package://pkg.pkl-lang.org/pkl-pantry/k8s.contrib.appEnvCluster@1.0.2#/*.pkl<caret>"
-    """
+      """
         .trimIndent()
     )
 

--- a/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
+++ b/src/test/kotlin/org/pkl/lsp/LspTestBase.kt
@@ -61,7 +61,7 @@ abstract class LspTestBase {
 
   private var caretPosition: Position? = null
 
-  private var fileInFocus: Path? = null
+  protected var fileInFocus: Path? = null
 
   private val modules: MutableMap<URI, PklModule> = HashMap()
 

--- a/src/test/kotlin/org/pkl/lsp/actions/PklAddModifierQuickfixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/actions/PklAddModifierQuickfixTest.kt
@@ -13,35 +13,36 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pkl.lsp
+package org.pkl.lsp.actions
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
+import org.pkl.lsp.LspTestBase
 
-class ModifierQuickfixTest : LspTestBase() {
+class PklAddModifierQuickfixTest : LspTestBase() {
   @Test
   fun `add modifier 'local' - no existing modifiers`() {
     val file =
       createPklVirtualFile(
         """
-     amends "pkl:test"
+        amends "pkl:test"
 
-     foo: String = "Hello"
-    """
+        foo: String = "Hello"
+        """
           .trimIndent()
       )
     val diagnostic = getSingleDiagnostic(file)
-    assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
+    Assertions.assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
     val action = diagnostic.actions.find { it.title == "Add modifier 'local'" }
-    assertThat(action).isNotNull
+    Assertions.assertThat(action).isNotNull
     runAction(action!!.toMessage(diagnostic))
-    assertThat(file.contents)
+    Assertions.assertThat(file.contents)
       .isEqualTo(
         """
-     amends "pkl:test"
+        amends "pkl:test"
 
-     local foo: String = "Hello"
-    """
+        local foo: String = "Hello"
+        """
           .trimIndent()
       )
   }
@@ -51,24 +52,24 @@ class ModifierQuickfixTest : LspTestBase() {
     val file =
       createPklVirtualFile(
         """
-     amends "pkl:test"
+        amends "pkl:test"
 
-     const foo: String = "Hello"
-    """
+        const foo: String = "Hello"
+        """
           .trimIndent()
       )
     val diagnostic = getSingleDiagnostic(file)
-    assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
+    Assertions.assertThat(diagnostic.message).isEqualTo("Missing modifier 'local'")
     val action = diagnostic.actions.find { it.title == "Add modifier 'local'" }
-    assertThat(action).isNotNull
+    Assertions.assertThat(action).isNotNull
     runAction(action!!.toMessage(diagnostic))
     assertThat(file.contents)
       .isEqualTo(
         """
-     amends "pkl:test"
+        amends "pkl:test"
 
-     local const foo: String = "Hello"
-    """
+        local const foo: String = "Hello"
+        """
           .trimIndent()
       )
   }

--- a/src/test/kotlin/org/pkl/lsp/actions/PklAddModifierQuickfixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/actions/PklAddModifierQuickfixTest.kt
@@ -63,7 +63,7 @@ class PklAddModifierQuickfixTest : LspTestBase() {
     val action = diagnostic.actions.find { it.title == "Add modifier 'local'" }
     Assertions.assertThat(action).isNotNull
     runAction(action!!.toMessage(diagnostic))
-    assertThat(file.contents)
+    Assertions.assertThat(file.contents)
       .isEqualTo(
         """
         amends "pkl:test"

--- a/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
@@ -572,4 +572,36 @@ class PklImplementMembersQuickFixTest : LspTestBase() {
         .trimIndent()
     )
   }
+
+  @Test
+  fun `quickfix only implements members not already declared`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+        abstract class Base {
+          abstract name: String
+          abstract age: Int
+        }
+        class Child extends Base {
+          name: String = "Bob"
+        }
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+        abstract class Base {
+          abstract name: String
+          abstract age: Int
+        }
+        class Child extends Base {
+          name: String = "Bob"
+
+          age: Int = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
 }

--- a/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
@@ -252,6 +252,7 @@ class PklImplementMembersQuickFixTest : LspTestBase() {
       extends "foo.pkl"
 
       bar: Int = TODO()
+
       """
         .trimIndent()
     )
@@ -457,6 +458,115 @@ class PklImplementMembersQuickFixTest : LspTestBase() {
 
       class Child extends foo.Base {
         foo: Bar = TODO()
+      }
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun `class with existing member`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+        abstract class Base {
+          abstract name: String
+        }
+        class Child extends Base {
+          bar: Int = 5
+        }
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+        abstract class Base {
+          abstract name: String
+        }
+        class Child extends Base {
+          bar: Int = 5
+
+          name: String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix does not reimplement fixed property that has an inherited default`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          fixed name: String = "default"
+          abstract function greet(): String
+        }
+
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          fixed name: String = "default"
+          abstract function greet(): String
+        }
+
+        class Child extends Base {
+          function greet(): String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `import type in different module, with chained alias conflicts`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+      import "bar.pkl"
+
+      abstract class Base {
+        abstract bar: bar.Qux
+      }
+      """
+        .trimIndent(),
+    )
+    createPklFile(
+      "bar.pkl",
+      """
+      class Qux
+      """
+        .trimIndent(),
+    )
+    createPklFile(
+      "test.pkl",
+      """
+      import "aaa.pkl" as bar2
+      import "foo.pkl"
+      import "other.pkl" as bar
+
+      class Child extends foo.Base
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      import "aaa.pkl" as bar2
+      import "bar.pkl" as bar3
+      import "foo.pkl"
+      import "other.pkl" as bar
+
+      class Child extends foo.Base {
+        bar: bar3.Qux = TODO()
       }
       """
         .trimIndent()

--- a/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/actions/PklImplementMembersQuickFixTest.kt
@@ -1,0 +1,465 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.actions
+
+import org.assertj.core.api.Assertions.assertThat
+import org.eclipse.lsp4j.CodeAction
+import org.junit.jupiter.api.Test
+import org.pkl.lsp.ErrorMessages
+import org.pkl.lsp.LspTestBase
+import org.pkl.lsp.VirtualFile
+
+class PklImplementMembersQuickFixTest : LspTestBase() {
+  private val quickFixTitle = ErrorMessages.create("implementMembers")
+
+  private fun checkQuickFix(before: String, after: String) {
+    createPklVirtualFile(before)
+    implementMembersAndAssertResultEqualTo(after)
+  }
+
+  private fun implementMembersAndAssertResultEqualTo(expectedResult: String) {
+    val file = fakeProject.virtualFileManager.get(fileInFocus!!)!!
+    runAction(getAction(file))
+    assertThat(file.contents).isEqualTo(expectedResult)
+  }
+
+  private fun getAction(file: VirtualFile): CodeAction {
+    for (diagnostic in getDiagnostics(file)) {
+      for (action in diagnostic.actions) {
+        if (action.title == quickFixTitle) {
+          return action.toMessage(diagnostic)
+        }
+      }
+    }
+    throw IllegalStateException("No implement members quickfix found")
+  }
+
+  @Test
+  fun `quickfix implements abstract property`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+        }
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+        }
+        class Child extends Base {
+          name: String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix implements abstract method`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract function greet(): String
+        }
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract function greet(): String
+        }
+        class Child extends Base {
+          function greet(): String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix fills fixed property value`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          fixed name: String
+        }
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          fixed name: String
+        }
+        class Child extends Base {
+          fixed name: String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix implements abstract fixed property`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract fixed name: String
+        }
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract fixed name: String
+        }
+        class Child extends Base {
+          fixed name: String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix implements multiple missing members`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+          abstract function greet(): String
+        }
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+          abstract function greet(): String
+        }
+        class Child extends Base {
+          name: String = TODO()
+
+          function greet(): String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix implements class members through nested hierarchy`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+          abstract function greet(): String
+        }
+
+        abstract class Base2 extends Base {}
+
+        class Child extends Base2 {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract name: String
+          abstract function greet(): String
+        }
+
+        abstract class Base2 extends Base {}
+
+        class Child extends Base2 {
+          name: String = TODO()
+
+          function greet(): String = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `quickfix implements module members`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+
+      abstract bar: Int
+      """
+        .trimIndent(),
+    )
+    createPklFile(
+      "test.pkl",
+      """
+      extends "foo.pkl"
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      extends "foo.pkl"
+
+      bar: Int = TODO()
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun `module type in same module`() {
+    checkQuickFix(
+      before =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract myModule: module
+        }
+
+        class Child extends Base {}
+        """
+          .trimIndent(),
+      after =
+        """
+        abstract module Foo
+
+        abstract class Base {
+          abstract myModule: module
+        }
+
+        class Child extends Base {
+          myModule: module = TODO()
+        }
+        """
+          .trimIndent(),
+    )
+  }
+
+  @Test
+  fun `import type in different module`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+
+      import "Bar.pkl"
+
+      abstract class Base {
+        abstract bar: Bar
+      }
+      """
+        .trimIndent(),
+    )
+
+    createPklFile("Bar.pkl", "")
+    createPklFile(
+      "test.pkl",
+      """
+      import "foo.pkl"
+
+      class Child extends foo.Base
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      import "Bar.pkl"
+      import "foo.pkl"
+
+      class Child extends foo.Base {
+        bar: Bar = TODO()
+      }
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun `import nested type in different module`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+
+      import "bar.pkl"
+
+      abstract class Base {
+        abstract bar: bar.Qux
+      }
+      """
+        .trimIndent(),
+    )
+
+    createPklFile(
+      "bar.pkl",
+      """
+      class Qux
+      """
+        .trimIndent(),
+    )
+    createPklFile(
+      "test.pkl",
+      """
+      import "foo.pkl"
+
+      class Child extends foo.Base
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      import "bar.pkl"
+      import "foo.pkl"
+
+      class Child extends foo.Base {
+        bar: bar.Qux = TODO()
+      }
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun `import type in different module, with conflicts`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+
+      import "bar.pkl"
+
+      abstract class Base {
+        abstract bar: bar.Qux
+      }
+      """
+        .trimIndent(),
+    )
+
+    createPklFile(
+      "bar.pkl",
+      """
+      class Qux
+      """
+        .trimIndent(),
+    )
+
+    createPklFile(
+      "test.pkl",
+      """
+      import "foo.pkl"
+      import "other.pkl" as bar
+
+      class Child extends foo.Base
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      import "bar.pkl" as bar2
+      import "foo.pkl"
+      import "other.pkl" as bar
+
+      class Child extends foo.Base {
+        bar: bar2.Qux = TODO()
+      }
+      """
+        .trimIndent()
+    )
+  }
+
+  @Test
+  fun `module type in different module`() {
+    createPklFile(
+      "foo.pkl",
+      """
+      abstract module foo
+
+      import "Bar.pkl"
+
+      abstract class Base extends Bar
+      """
+        .trimIndent(),
+    )
+
+    createPklFile(
+      "Bar.pkl",
+      """
+      abstract foo: module
+      """
+        .trimIndent(),
+    )
+
+    createPklFile(
+      "test.pkl",
+      """
+      import "foo.pkl"
+
+      class Child extends foo.Base
+      """
+        .trimIndent(),
+    )
+    implementMembersAndAssertResultEqualTo(
+      """
+      import "Bar.pkl"
+      import "foo.pkl"
+
+      class Child extends foo.Base {
+        foo: Bar = TODO()
+      }
+      """
+        .trimIndent()
+    )
+  }
+}

--- a/src/test/kotlin/org/pkl/lsp/completion/CompletionFeatureTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/completion/CompletionFeatureTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.pkl.lsp
+package org.pkl.lsp.completion
 
 import java.nio.file.Path
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import org.pkl.lsp.completion.ModuleUriCompletionProvider.Companion.ModuleUriCompletionData
+import org.pkl.lsp.LspTestBase
 
 class CompletionFeatureTest : LspTestBase() {
   @Test
   fun `complete amends header`() {
     createPklFile("amends \"<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label })
+    Assertions.assertThat(completions.map { it.label })
       .isEqualTo(listOf("pkl:", "file:///", "https://", "package://", "modulepath:/", "main.pkl"))
   }
 
@@ -34,7 +34,7 @@ class CompletionFeatureTest : LspTestBase() {
   fun `complete import`() {
     createPklFile("import \"<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label })
+    Assertions.assertThat(completions.map { it.label })
       .isEqualTo(listOf("pkl:", "file:///", "https://", "package://", "modulepath:/", "main.pkl"))
   }
 
@@ -42,7 +42,7 @@ class CompletionFeatureTest : LspTestBase() {
   fun `complete import expression`() {
     createPklFile("res = import(\"<caret>\")")
     val completions = getCompletions()
-    assertThat(completions.map { it.label })
+    Assertions.assertThat(completions.map { it.label })
       .isEqualTo(listOf("pkl:", "file:///", "https://", "package://", "modulepath:/", "main.pkl"))
   }
 
@@ -54,7 +54,7 @@ class CompletionFeatureTest : LspTestBase() {
     createPklFile("lib/target.pkl", "")
     createPklFile("import \"modulepath:/<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
+    Assertions.assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
   }
 
   @Test
@@ -66,7 +66,10 @@ class CompletionFeatureTest : LspTestBase() {
     val targetPath = createPklFile(modulepath1.resolve("target.pkl"), "")
     createPklFile(modulepath2.resolve("target.pkl"), "")
     createPklFile("import \"modulepath:/<caret>\"")
-    val completions = getCompletions().map { (it.data as ModuleUriCompletionData).moduleUri }
+    val completions =
+      getCompletions().map {
+        (it.data as ModuleUriCompletionProvider.Companion.ModuleUriCompletionData).moduleUri
+      }
     assert(completions.size == 1)
     assert(completions[0] == targetPath.toUri().toString())
   }
@@ -78,7 +81,7 @@ class CompletionFeatureTest : LspTestBase() {
     createArchive(libJar, mapOf("file.pkl" to "", "dir/file2.pkl" to ""))
     createPklFile("import \"modulepath:/<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).isEqualTo(listOf("dir", "file.pkl"))
+    Assertions.assertThat(completions.map { it.label }).isEqualTo(listOf("dir", "file.pkl"))
   }
 
   @Test
@@ -88,7 +91,7 @@ class CompletionFeatureTest : LspTestBase() {
     createArchive(libJar, mapOf("dir/target.pkl" to ""))
     createPklFile("import \"modulepath:/dir/<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
+    Assertions.assertThat(completions.map { it.label }).isEqualTo(listOf("target.pkl"))
   }
 
   @Test
@@ -97,7 +100,8 @@ class CompletionFeatureTest : LspTestBase() {
     createPklFile(tempDir.resolve("bar.pkl").toString(), "bar = 1")
     createPklFile(tempDir.resolve("foo.pkl").toString(), "import \"/<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).hasSameElementsAs(listOf("bar.pkl", "foo.pkl"))
+    Assertions.assertThat(completions.map { it.label })
+      .hasSameElementsAs(listOf("bar.pkl", "foo.pkl"))
   }
 
   @Test
@@ -109,7 +113,8 @@ class CompletionFeatureTest : LspTestBase() {
     createPklFile(tempDir1.resolve("bar/baz.pkl").toString(), "bar = 1")
     createPklFile(tempDir2.resolve("bar/foo.pkl").toString(), "import \"./<caret>\"")
     val completions = getCompletions()
-    assertThat(completions.map { it.label }).hasSameElementsAs(listOf("baz.pkl", "foo.pkl"))
+    Assertions.assertThat(completions.map { it.label })
+      .hasSameElementsAs(listOf("baz.pkl", "foo.pkl"))
   }
 
   @Test

--- a/src/test/kotlin/org/pkl/lsp/completion/ImplementMembersCompletionTest.kt
+++ b/src/test/kotlin/org/pkl/lsp/completion/ImplementMembersCompletionTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2026 Apple Inc. and the Pkl project authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.pkl.lsp.completion
+
+import org.junit.jupiter.api.Test
+import org.pkl.lsp.LspTestBase
+
+class ImplementMembersCompletionTest : LspTestBase() {
+  @Test
+  fun `complete abstract method`() {
+    createPklFile(
+      """
+      abstract class Base {
+        abstract function bar(): Int
+      }
+
+      class MyClass extends Base {
+        b<caret>
+      }
+      """
+        .trimIndent()
+    )
+    val completions = getCompletions()
+    val methodCompletion = completions.find { it.label == "function bar(): Int = …" }
+    assert(methodCompletion != null)
+  }
+}


### PR DESCRIPTION
Also, this adds a quickfix for implementing members.

* Insert members and also imports when needed
* Refactor: merge `shortDisplayName` and `name` (they are duplicate properties that mean the same thing)
* Move `ModifierQuickfixTest` to `PklAddModifierQuickFixTest`; make sibling of new test
* Fix add modifier logic when no module header exists