### PR TITLE
Add support for `this` type

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -332,6 +332,7 @@ fun configureRepo(
   simpleRepoName: String,
   gitTagOrCommit: Provider<String>,
   repoDir: Provider<Directory>,
+  additionalRemoteUrl: String? = null,
 ): TaskProvider<Task> {
   val taskSuffix = simpleRepoName.capitalized() + "Repo"
 
@@ -395,6 +396,7 @@ val setupTreeSitterPklRepo =
     "treeSitterPkl",
     libs.versions.treeSitterPklRepo,
     treeSitterPklRepoDir,
+    System.getenv("PKL_TREE_SITTER_PKL_ADDITIONAL_REMOTE_URL"),
   )
 
 val oses by lazy {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,8 @@ pkl = "0.32.0"
 shadowPlugin = "9.5.1"
 spotless = "8.8.0"
 treeSitterRepo = "v0.26.8" # git tag name
-treeSitterPklRepo = "v0.21.0" # git tag name
+treeSitterPklRepo = "65f4483b9e8a5960a4d8948421ef3a8992013517" # TODO: switch to tag once released
+#treeSitterPklRepo = "v0.21.0" # git tag name
 
 # Only need checksums for distributions that we might run builds on.
 # used for cross-compiling tree-sitter libs

--- a/src/devLauncher/kotlin/org/pkl/lsp/devlauncher/Launcher.kt
+++ b/src/devLauncher/kotlin/org/pkl/lsp/devlauncher/Launcher.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright © 2025 Apple Inc. and the Pkl project authors. All rights reserved.
+ * Copyright © 2025-2026 Apple Inc. and the Pkl project authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,7 @@ class Launcher : CliktCommand() {
   private val pklVscodeDir: Path by lazy { projectRootDir.resolve("../pkl-vscode") }
 
   // The target directory to open; configurable with ARGV.
-  private val defaultWorkspace: Path by lazy { projectRootDir.resolve("../pkl-pantry") }
+  private val defaultWorkspace: Path by lazy { projectRootDir.resolve("../pkl") }
 
   private fun prepareUserDataDir(port: Int, pklCliPath: Path) {
     val settingsFile =

--- a/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
+++ b/src/main/kotlin/org/pkl/lsp/PklVisitor.kt
@@ -195,6 +195,10 @@ open class PklVisitor<R> {
     return visitType(node)
   }
 
+  open fun visitThisType(node: PklThisType): R? {
+    return visitType(node)
+  }
+
   open fun visitModuleUri(node: PklModuleUri): R? {
     return visitElement(node)
   }

--- a/src/main/kotlin/org/pkl/lsp/analyzers/TypeAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/TypeAnalyzer.kt
@@ -18,8 +18,14 @@ package org.pkl.lsp.analyzers
 import org.pkl.lsp.ErrorMessages
 import org.pkl.lsp.PklBaseModule
 import org.pkl.lsp.Project
+import org.pkl.lsp.ast.PklAnnotation
+import org.pkl.lsp.ast.PklClassBody
 import org.pkl.lsp.ast.PklDeclaredType
+import org.pkl.lsp.ast.PklModuleType
 import org.pkl.lsp.ast.PklNode
+import org.pkl.lsp.ast.PklThisType
+import org.pkl.lsp.ast.PklTypeAlias
+import org.pkl.lsp.ast.parentOfType
 import org.pkl.lsp.packages.dto.PklProject
 import org.pkl.lsp.type.Type
 import org.pkl.lsp.type.toType
@@ -27,39 +33,48 @@ import org.pkl.lsp.type.toType
 class TypeAnalyzer(project: Project) : Analyzer(project) {
   override fun doAnalyze(node: PklNode, diagnosticsHolder: DiagnosticsHolder): Boolean =
     when {
-      node is PklDeclaredType && !node.typeArgumentList?.types.isNullOrEmpty() -> {
-        val type = node.toType(project.pklBaseModule, emptyMap(), node.containingFile.pklProject)
-
-        val argCount = node.typeArgumentList!!.types.size
-        val paramCount =
-          when (type) {
-            is Type.Class -> type.typeArguments.size
-            is Type.Alias -> type.typeArguments.size
-            else -> 0
-          }
-        if (paramCount != 0 && paramCount != argCount) {
-          diagnosticsHolder.addError(
-            node,
-            ErrorMessages.create("incorrectTypeArgumentCount", paramCount, argCount),
-          )
-          return false
-        }
-
-        val unaliased = type.unaliased(project.pklBaseModule, node.containingFile.pklProject)
-        if (
-          unaliased is Type.Reference &&
-            type.containsConstrainedType(project.pklBaseModule, node.containingFile.pklProject)
-        ) {
-          diagnosticsHolder.addError(
-            node,
-            ErrorMessages.create("invalidReferenceTypeWithConstraint"),
-          )
-        }
-
+      node is PklDeclaredType -> {
+        validateDeclaredType(node, diagnosticsHolder)
+        false
+      }
+      node is PklModuleType -> {
+        validateModuleType(node, diagnosticsHolder)
+        false
+      }
+      node is PklThisType -> {
+        validateThisType(node, diagnosticsHolder)
         false
       }
       else -> true
     }
+
+  private fun validateDeclaredType(node: PklDeclaredType, diagnosticsHolder: DiagnosticsHolder) {
+    if (node.typeArgumentList?.types.isNullOrEmpty()) return
+
+    val type = node.toType(project.pklBaseModule, emptyMap(), node.containingFile.pklProject)
+    val argCount = node.typeArgumentList!!.types.size
+    val paramCount =
+      when (type) {
+        is Type.Class -> type.typeArguments.size
+        is Type.Alias -> type.typeArguments.size
+        else -> 0
+      }
+    if (paramCount != 0 && paramCount != argCount) {
+      diagnosticsHolder.addError(
+        node,
+        ErrorMessages.create("incorrectTypeArgumentCount", paramCount, argCount),
+      )
+      return
+    }
+
+    val unaliased = type.unaliased(project.pklBaseModule, node.containingFile.pklProject)
+    if (
+      unaliased is Type.Reference &&
+        type.containsConstrainedType(project.pklBaseModule, node.containingFile.pklProject)
+    ) {
+      diagnosticsHolder.addError(node, ErrorMessages.create("invalidReferenceTypeWithConstraint"))
+    }
+  }
 
   private fun Type.containsConstrainedType(base: PklBaseModule, context: PklProject?): Boolean =
     !constraints.isEmpty() ||
@@ -73,4 +88,36 @@ class TypeAnalyzer(project: Project) : Analyzer(project) {
             rightType.containsConstrainedType(base, context)
         else -> false
       }
+
+  private fun validateModuleType(node: PklModuleType, diagnosticsHolder: DiagnosticsHolder) {
+    // allowed in annotations
+    if (node.parentOfType<PklAnnotation>() != null) return
+    if (node.parentOfType<PklTypeAlias>() != null) {
+      // not allowed in typealias bodies
+      diagnosticsHolder.addWarning(
+        node,
+        ErrorMessages.create("invalidSelfTypeUsage", "module", "type alias") +
+          " This will be an error in a future release.",
+      )
+    } else if (node.parentOfType<PklClassBody>() != null) {
+      // not allowed in class bodies
+      diagnosticsHolder.addWarning(
+        node,
+        ErrorMessages.create("invalidSelfTypeUsage", "module", "class") +
+          " This will be an error in a future release.",
+      )
+    }
+  }
+
+  private fun validateThisType(node: PklThisType, diagnosticsHolder: DiagnosticsHolder) {
+    // allowed in annotations
+    if (node.parentOfType<PklAnnotation>() != null) return
+    if (node.parentOfType<PklTypeAlias>() != null) {
+      // not allowed in typealias bodies
+      diagnosticsHolder.addError(
+        node,
+        ErrorMessages.create("invalidSelfTypeUsage", "this", "type alias"),
+      )
+    }
+  }
 }

--- a/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Extensions.kt
@@ -643,6 +643,7 @@ fun Appendable.renderType(
     is PklStringLiteralType -> append(type.stringConstant.text)
     is PklNothingType -> append("nothing")
     is PklModuleType -> append("module")
+    is PklThisType -> append("this")
     is PklUnknownType -> append("unknown")
   }
 

--- a/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/PklNode.kt
@@ -724,6 +724,10 @@ interface PklModuleType : PklType {
   override fun render(): String = "module"
 }
 
+interface PklThisType : PklType {
+  override fun render(): String = "this"
+}
+
 interface PklStringLiteralType : PklType {
   val stringConstant: PklStringConstant
 
@@ -954,6 +958,7 @@ fun Node.toNode(project: Project, parent: PklNode?): PklNode? {
     "unknownType" -> PklUnknownTypeImpl(project, parent!!, this)
     "nothingType" -> PklNothingTypeImpl(project, parent!!, this)
     "moduleType" -> PklModuleTypeImpl(project, parent!!, this)
+    "thisType" -> PklThisTypeImpl(project, parent!!, this)
     "stringLiteralType" -> PklStringLiteralTypeImpl(project, parent!!, this)
     "declaredType" -> PklDeclaredTypeImpl(project, parent!!, this, false)
     "parenthesizedType" -> PklParenthesizedTypeImpl(project, parent!!, this)

--- a/src/main/kotlin/org/pkl/lsp/ast/Type.kt
+++ b/src/main/kotlin/org/pkl/lsp/ast/Type.kt
@@ -55,6 +55,13 @@ class PklModuleTypeImpl(project: Project, override val parent: PklNode, ctx: Nod
   }
 }
 
+class PklThisTypeImpl(project: Project, override val parent: PklNode, ctx: Node) :
+  AbstractPklNode(project, parent, ctx), PklThisType {
+  override fun <R> accept(visitor: PklVisitor<R>): R? {
+    return visitor.visitThisType(this)
+  }
+}
+
 class PklStringLiteralTypeImpl(project: Project, override val parent: PklNode, ctx: Node) :
   AbstractPklNode(project, parent, ctx), PklStringLiteralType {
   // TODO: check if `stringConstant` is a child

--- a/src/main/kotlin/org/pkl/lsp/completion/UnqualifiedAccessCompletionProvider.kt
+++ b/src/main/kotlin/org/pkl/lsp/completion/UnqualifiedAccessCompletionProvider.kt
@@ -381,7 +381,7 @@ class UnqualifiedAccessCompletionProvider(private val project: Project) : Comple
       if (propertyName in alreadyDefinedProperties) continue
       if (property.isFixedOrConst && !isClassOrModule) continue
 
-      val propertyType = property.type.toType(base, thisType.bindings, context)
+      val propertyType = property.type.toType(base, thisType.bindings, context) { thisType }
       val amendedPropertyType = propertyType.amended(base, context)
       if (amendedPropertyType != Type.Nothing && amendedPropertyType != Type.Unknown) {
         collector += createPropertyAmendElement(propertyName, property)

--- a/src/main/kotlin/org/pkl/lsp/type/Types.kt
+++ b/src/main/kotlin/org/pkl/lsp/type/Types.kt
@@ -1418,6 +1418,7 @@ fun PklType?.toType(
   bindings: Map<PklTypeParameter, Type>,
   context: PklProject?,
   preserveUnboundTypeVars: Boolean = false,
+  getThisType: () -> Type = { this?.computeThisType(base, bindings, context) ?: Type.Nothing },
 ): Type =
   when (this) {
     null -> Type.Unknown
@@ -1430,7 +1431,7 @@ fun PklType?.toType(
           val typeArguments = this.typeArgumentList?.types ?: listOf()
           Type.Class.create(
             resolved,
-            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars),
+            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars, getThisType),
           )
         }
         is PklTypeAlias -> {
@@ -1438,7 +1439,7 @@ fun PklType?.toType(
           Type.alias(
             resolved,
             context,
-            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars),
+            typeArguments.toTypes(base, bindings, context, preserveUnboundTypeVars, getThisType),
           )
         }
         is PklTypeParameter ->
@@ -1449,14 +1450,16 @@ fun PklType?.toType(
     }
     is PklUnionType ->
       Type.union(
-        leftType.toType(base, bindings, context, preserveUnboundTypeVars),
-        rightType.toType(base, bindings, context, preserveUnboundTypeVars),
+        leftType.toType(base, bindings, context, preserveUnboundTypeVars, getThisType),
+        rightType.toType(base, bindings, context, preserveUnboundTypeVars, getThisType),
         base,
         context,
       )
     is PklFunctionType -> {
-      val parameterTypes = parameterList.toTypes(base, bindings, context, preserveUnboundTypeVars)
-      val returnType = returnType.toType(base, bindings, context, preserveUnboundTypeVars)
+      val parameterTypes =
+        parameterList.toTypes(base, bindings, context, preserveUnboundTypeVars, getThisType)
+      val returnType =
+        returnType.toType(base, bindings, context, preserveUnboundTypeVars, getThisType)
       when (parameterTypes.size) {
         0 -> base.function0Type.withTypeArguments(parameterTypes + returnType)
         1 -> base.function1Type.withTypeArguments(parameterTypes + returnType)
@@ -1470,21 +1473,28 @@ fun PklType?.toType(
           ) // approximation (invalid Pkl code)
       }
     }
-    is PklParenthesizedType -> type.toType(base, bindings, context, preserveUnboundTypeVars)
-    is PklDefaultUnionType -> type.toType(base, bindings, context, preserveUnboundTypeVars)
+    is PklParenthesizedType ->
+      type.toType(base, bindings, context, preserveUnboundTypeVars, getThisType)
+    is PklDefaultUnionType ->
+      type.toType(base, bindings, context, preserveUnboundTypeVars, getThisType)
     is PklConstrainedType -> {
       // TODO: cache `constraintExprs`
       val constraintExprs = exprs.toConstraintExprs(project.pklBaseModule, context)
-      type.toType(base, bindings, context, preserveUnboundTypeVars).withConstraints(constraintExprs)
+      type
+        .toType(base, bindings, context, preserveUnboundTypeVars, getThisType)
+        .withConstraints(constraintExprs)
     }
     is PklNullableType ->
-      type.toType(base, bindings, context, preserveUnboundTypeVars).nullable(base, context)
+      type
+        .toType(base, bindings, context, preserveUnboundTypeVars, getThisType)
+        .nullable(base, context)
     is PklUnknownType -> Type.Unknown
     is PklNothingType -> Type.Nothing
     is PklModuleType -> {
       // TODO: for `open` modules, `module` is a self-type
       enclosingModule?.let { Type.module(it, "module", context) } ?: base.moduleType
     }
+    is PklThisType -> getThisType()
     is PklStringLiteralType ->
       stringConstant.escapedText()?.let { Type.StringLiteral(it) } ?: Type.Unknown
     is PklTypeParameter ->
@@ -1496,4 +1506,5 @@ fun List<PklType>.toTypes(
   bindings: Map<PklTypeParameter, Type>,
   context: PklProject?,
   preserveTypeVariables: Boolean = false,
-): List<Type> = map { it.toType(base, bindings, context, preserveTypeVariables) }
+  getThisType: () -> Type,
+): List<Type> = map { it.toType(base, bindings, context, preserveTypeVariables, getThisType) }

--- a/src/main/resources/org/pkl/lsp/errorMessages.properties
+++ b/src/main/resources/org/pkl/lsp/errorMessages.properties
@@ -244,3 +244,6 @@ entityDoesNotDefineDefaultValue=\
 
 implementMembers=\
 Implement members
+
+invalidSelfTypeUsage=\
+`{0}` type annotations are not allowed in {1} bodies.


### PR DESCRIPTION
Also adds a utility for using tree-sitter-pkl refs from a fork (i.e. an unmerged PR like https://github.com/apple/tree-sitter-pkl/pull/86)