### PR TITLE
Downgrade abstract member severity

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
@@ -115,7 +115,7 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
           val message =
             if (containingClass is PklModule) "cannotDeclareAbstractInNonAbstractModule"
             else "cannotDeclareAbstractInNonAbstractClass"
-          diagnosticsHolder.addError(abstractModifier, ErrorMessages.create(message))
+          diagnosticsHolder.addWarning(abstractModifier, ErrorMessages.create(message))
         }
       }
     }

--- a/src/main/resources/org/pkl/lsp/errorMessages.properties
+++ b/src/main/resources/org/pkl/lsp/errorMessages.properties
@@ -8,10 +8,10 @@ modifierOpenConflictsWithAbstract=\
 Modifier 'open' conflicts with 'abstract'
 
 cannotDeclareAbstractInNonAbstractModule=\
-Cannot declare an 'abstract' members in a non-abstract module.
+Abstract member declared in a non-abstract module. This will be an error in the future.
 
 cannotDeclareAbstractInNonAbstractClass=\
-Cannot declare an 'abstract' members in a non-abstract class.
+Abstract member declared in a non-abstract class. This will be an error in the future.
 
 missingModifierLocal=\
 Missing modifier 'local'

--- a/src/test/files/DiagnosticsSnippetTests/output/modifiers/abstractModifierInNonAbstract.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/modifiers/abstractModifierInNonAbstract.txt
@@ -1,22 +1,22 @@
  abstract foo: Int
  ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract module.
+| Warning: Abstract member declared in a non-abstract module. This will be an error in the future.
  
  abstract function foo(): Int
  ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract module.
+| Warning: Abstract member declared in a non-abstract module. This will be an error in the future.
  ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract module.
+| Warning: Abstract member declared in a non-abstract module. This will be an error in the future.
  
  class MyClass {
    abstract foo: Int
    ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract class.
+| Warning: Abstract member declared in a non-abstract class. This will be an error in the future.
  
    abstract function foo(): Int
    ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract class.
+| Warning: Abstract member declared in a non-abstract class. This will be an error in the future.
    ^^^^^^^^
-| Error: Cannot declare an 'abstract' members in a non-abstract class.
+| Warning: Abstract member declared in a non-abstract class. This will be an error in the future.
  }
  


### PR DESCRIPTION
We removed this check for the 0.32 release, so this diagnostic is downgraded to a warning level.