### PR TITLE
Fix analysis of abstract class in non-abstract module

### DIFF
--- a/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
+++ b/src/main/kotlin/org/pkl/lsp/analyzers/ModifierAnalyzer.kt
@@ -104,7 +104,8 @@ class ModifierAnalyzer(project: Project) : Analyzer(project) {
       }
     }
 
-    if (abstractModifier != null) {
+    // okay to declare abstract class in non-abstract module
+    if (abstractModifier != null && node !is PklClass) {
       val containingClass =
         node.parentOfTypes(PklModule::class, PklClass::class, /* stop class */ PklObjectBody::class)
           as? PklModifierListOwner

--- a/src/test/files/DiagnosticsSnippetTests/input/modifiers/abstractModifierInNonAbstract.pkl
+++ b/src/test/files/DiagnosticsSnippetTests/input/modifiers/abstractModifierInNonAbstract.pkl
@@ -7,3 +7,6 @@ class MyClass {
 
   abstract function foo(): Int
 }
+
+// abstract class is okay
+abstract class MyAbstractClass

--- a/src/test/files/DiagnosticsSnippetTests/output/modifiers/abstractModifierInNonAbstract.txt
+++ b/src/test/files/DiagnosticsSnippetTests/output/modifiers/abstractModifierInNonAbstract.txt
@@ -20,3 +20,6 @@
 | Warning: Abstract member declared in a non-abstract class. This will be an error in the future.
  }
  
+ // abstract class is okay
+ abstract class MyAbstractClass
+ 


### PR DESCRIPTION
Abstract classes are "static" members; it's okay to declare an abstract class in a non-abstract module.

This matches the analysis behavior in pkl-intellij.